### PR TITLE
Add generated models output and check changes

### DIFF
--- a/tests/sample_models/junit10/junit10_ddl_mssql_version0.sql
+++ b/tests/sample_models/junit10/junit10_ddl_mssql_version0.sql
@@ -1,0 +1,275 @@
+
+CREATE TABLE error (
+	pk_error INTEGER NOT NULL IDENTITY, 
+	type VARCHAR(1000) NULL, 
+	message VARCHAR(1000) NULL, 
+	value VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_error PRIMARY KEY CLUSTERED (pk_error), 
+	CONSTRAINT error_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE failure (
+	pk_failure INTEGER NOT NULL IDENTITY, 
+	type VARCHAR(1000) NULL, 
+	message VARCHAR(1000) NULL, 
+	value VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_failure PRIMARY KEY CLUSTERED (pk_failure), 
+	CONSTRAINT failure_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE property (
+	pk_property INTEGER NOT NULL IDENTITY, 
+	name VARCHAR(1000) NULL, 
+	value VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_property PRIMARY KEY CLUSTERED (pk_property), 
+	CONSTRAINT property_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [flakyError] (
+	[pk_flakyError] INTEGER NOT NULL IDENTITY, 
+	message VARCHAR(1000) NULL, 
+	type VARCHAR(1000) NULL, 
+	[stackTrace] VARCHAR(1000) NULL, 
+	[system-out] VARCHAR(1000) NULL, 
+	[system-err] VARCHAR(1000) NULL, 
+	value VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_flakyError] PRIMARY KEY CLUSTERED ([pk_flakyError]), 
+	CONSTRAINT [flakyError_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE skipped (
+	pk_skipped INTEGER NOT NULL IDENTITY, 
+	type VARCHAR(1000) NULL, 
+	message VARCHAR(1000) NULL, 
+	value VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_skipped PRIMARY KEY CLUSTERED (pk_skipped), 
+	CONSTRAINT skipped_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE properties (
+	pk_properties INTEGER NOT NULL IDENTITY, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_properties PRIMARY KEY CLUSTERED (pk_properties), 
+	CONSTRAINT properties_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE properties_property (
+	fk_properties INTEGER NOT NULL, 
+	fk_property INTEGER NOT NULL, 
+	FOREIGN KEY(fk_properties) REFERENCES properties (pk_properties), 
+	FOREIGN KEY(fk_property) REFERENCES property (pk_property)
+)
+
+
+CREATE TABLE testcase (
+	pk_testcase INTEGER NOT NULL IDENTITY, 
+	classname VARCHAR(1000) NULL, 
+	name VARCHAR(1000) NULL, 
+	time VARCHAR(1000) NULL, 
+	[group] VARCHAR(1000) NULL, 
+	[system-out] VARCHAR(8000) NULL, 
+	[system-err] VARCHAR(8000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_testcase PRIMARY KEY CLUSTERED (pk_testcase), 
+	CONSTRAINT testcase_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE testcase_skipped (
+	fk_testcase INTEGER NOT NULL, 
+	fk_skipped INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_skipped) REFERENCES skipped (pk_skipped)
+)
+
+
+CREATE TABLE testcase_error (
+	fk_testcase INTEGER NOT NULL, 
+	fk_error INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_error) REFERENCES error (pk_error)
+)
+
+
+CREATE TABLE testcase_failure (
+	fk_testcase INTEGER NOT NULL, 
+	fk_failure INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_failure) REFERENCES failure (pk_failure)
+)
+
+
+CREATE TABLE [testcase_rerunFailure_flakyError] (
+	fk_testcase INTEGER NOT NULL, 
+	[fk_flakyError] INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY([fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError])
+)
+
+
+CREATE TABLE [testcase_rerunError_flakyError] (
+	fk_testcase INTEGER NOT NULL, 
+	[fk_flakyError] INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY([fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError])
+)
+
+
+CREATE TABLE [testcase_flakyFailure_flakyError] (
+	fk_testcase INTEGER NOT NULL, 
+	[fk_flakyError] INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY([fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError])
+)
+
+
+CREATE TABLE [testcase_flakyError] (
+	fk_testcase INTEGER NOT NULL, 
+	[fk_flakyError] INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY([fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError])
+)
+
+
+CREATE TABLE testsuite (
+	pk_testsuite INTEGER NOT NULL IDENTITY, 
+	name VARCHAR(1000) NULL, 
+	errors VARCHAR(1000) NULL, 
+	failures VARCHAR(1000) NULL, 
+	skipped VARCHAR(1000) NULL, 
+	tests VARCHAR(1000) NULL, 
+	[group] VARCHAR(1000) NULL, 
+	time VARCHAR(1000) NULL, 
+	timestamp VARCHAR(1000) NULL, 
+	hostname VARCHAR(1000) NULL, 
+	id VARCHAR(1000) NULL, 
+	package VARCHAR(1000) NULL, 
+	[file] VARCHAR(1000) NULL, 
+	log VARCHAR(1000) NULL, 
+	url VARCHAR(1000) NULL, 
+	version VARCHAR(1000) NULL, 
+	[system-out] VARCHAR(8000) NULL, 
+	[system-err] VARCHAR(8000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_testsuite PRIMARY KEY CLUSTERED (pk_testsuite), 
+	CONSTRAINT testsuite_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE testsuite_properties (
+	fk_testsuite INTEGER NOT NULL, 
+	fk_properties INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite), 
+	FOREIGN KEY(fk_properties) REFERENCES properties (pk_properties)
+)
+
+
+CREATE TABLE testsuite_testcase (
+	fk_testsuite INTEGER NOT NULL, 
+	fk_testcase INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite), 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase)
+)
+
+
+CREATE TABLE junit10 (
+	pk_junit10 INTEGER NOT NULL IDENTITY, 
+	fk_error INTEGER NULL, 
+	fk_failure INTEGER NULL, 
+	[fk_flakyError] INTEGER NULL, 
+	[flakyFailure_fk_flakyError] INTEGER NULL, 
+	fk_properties INTEGER NULL, 
+	fk_property INTEGER NULL, 
+	[rerunError_fk_flakyError] INTEGER NULL, 
+	[rerunFailure_fk_flakyError] INTEGER NULL, 
+	fk_skipped INTEGER NULL, 
+	[system-err] VARCHAR(1000) NULL, 
+	[system-out] VARCHAR(1000) NULL, 
+	fk_testcase INTEGER NULL, 
+	fk_testsuite INTEGER NULL, 
+	testsuites_name VARCHAR(1000) NULL, 
+	testsuites_time VARCHAR(1000) NULL, 
+	testsuites_tests VARCHAR(1000) NULL, 
+	testsuites_failures VARCHAR(1000) NULL, 
+	testsuites_errors VARCHAR(1000) NULL, 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at DATETIMEOFFSET NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_junit10 PRIMARY KEY CLUSTERED (pk_junit10), 
+	CONSTRAINT junit10_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY(fk_error) REFERENCES error (pk_error), 
+	FOREIGN KEY(fk_failure) REFERENCES failure (pk_failure), 
+	FOREIGN KEY([fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError]), 
+	FOREIGN KEY([flakyFailure_fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError]), 
+	FOREIGN KEY(fk_properties) REFERENCES properties (pk_properties), 
+	FOREIGN KEY(fk_property) REFERENCES property (pk_property), 
+	FOREIGN KEY([rerunError_fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError]), 
+	FOREIGN KEY([rerunFailure_fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError]), 
+	FOREIGN KEY(fk_skipped) REFERENCES skipped (pk_skipped), 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite)
+)
+
+
+CREATE TABLE junit10_testsuite (
+	fk_junit10 INTEGER NOT NULL, 
+	fk_testsuite INTEGER NOT NULL, 
+	FOREIGN KEY(fk_junit10) REFERENCES junit10 (pk_junit10), 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite)
+)
+
+CREATE INDEX ix_properties_property_fk_property ON properties_property (fk_property)
+
+CREATE INDEX ix_testcase_skipped_fk_skipped ON testcase_skipped (fk_skipped)
+
+CREATE INDEX ix_testcase_error_fk_error ON testcase_error (fk_error)
+
+CREATE INDEX ix_testcase_failure_fk_failure ON testcase_failure (fk_failure)
+
+CREATE INDEX [ix_testcase_rerunFailure_flakyError_fk_flakyError] ON [testcase_rerunFailure_flakyError] ([fk_flakyError])
+
+CREATE INDEX [ix_testcase_rerunError_flakyError_fk_flakyError] ON [testcase_rerunError_flakyError] ([fk_flakyError])
+
+CREATE INDEX [ix_testcase_flakyFailure_flakyError_fk_flakyError] ON [testcase_flakyFailure_flakyError] ([fk_flakyError])
+
+CREATE INDEX [ix_testcase_flakyError_fk_flakyError] ON [testcase_flakyError] ([fk_flakyError])
+
+CREATE INDEX ix_testsuite_properties_fk_properties ON testsuite_properties (fk_properties)
+
+CREATE INDEX ix_testsuite_testcase_fk_testcase ON testsuite_testcase (fk_testcase)
+
+CREATE INDEX ix_junit10_fk_error ON junit10 (fk_error)
+
+CREATE INDEX ix_junit10_fk_failure ON junit10 (fk_failure)
+
+CREATE INDEX [ix_junit10_fk_flakyError] ON junit10 ([fk_flakyError])
+
+CREATE INDEX ix_junit10_fk_properties ON junit10 (fk_properties)
+
+CREATE INDEX ix_junit10_fk_property ON junit10 (fk_property)
+
+CREATE INDEX ix_junit10_fk_skipped ON junit10 (fk_skipped)
+
+CREATE INDEX ix_junit10_fk_testcase ON junit10 (fk_testcase)
+
+CREATE INDEX ix_junit10_fk_testsuite ON junit10 (fk_testsuite)
+
+CREATE INDEX [ix_junit10_flakyFailure_fk_flakyError] ON junit10 ([flakyFailure_fk_flakyError])
+
+CREATE INDEX [ix_junit10_rerunError_fk_flakyError] ON junit10 ([rerunError_fk_flakyError])
+
+CREATE INDEX [ix_junit10_rerunFailure_fk_flakyError] ON junit10 ([rerunFailure_fk_flakyError])
+
+CREATE INDEX ix_junit10_testsuite_fk_testsuite ON junit10_testsuite (fk_testsuite)
+

--- a/tests/sample_models/junit10/junit10_ddl_mssql_version1.sql
+++ b/tests/sample_models/junit10/junit10_ddl_mssql_version1.sql
@@ -1,0 +1,287 @@
+
+CREATE TABLE error (
+	pk_error INTEGER NOT NULL IDENTITY, 
+	type VARCHAR(1000) NULL, 
+	message VARCHAR(1000) NULL, 
+	value VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_error PRIMARY KEY CLUSTERED (pk_error), 
+	CONSTRAINT error_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE failure (
+	pk_failure INTEGER NOT NULL IDENTITY, 
+	type VARCHAR(1000) NULL, 
+	message VARCHAR(1000) NULL, 
+	value VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_failure PRIMARY KEY CLUSTERED (pk_failure), 
+	CONSTRAINT failure_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE property (
+	pk_property INTEGER NOT NULL IDENTITY, 
+	name VARCHAR(1000) NULL, 
+	value VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_property PRIMARY KEY CLUSTERED (pk_property), 
+	CONSTRAINT property_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [flakyError] (
+	[pk_flakyError] INTEGER NOT NULL IDENTITY, 
+	message VARCHAR(1000) NULL, 
+	type VARCHAR(1000) NULL, 
+	[stackTrace] VARCHAR(1000) NULL, 
+	[system-out] VARCHAR(1000) NULL, 
+	[system-err] VARCHAR(1000) NULL, 
+	value VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_flakyError] PRIMARY KEY CLUSTERED ([pk_flakyError]), 
+	CONSTRAINT [flakyError_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE skipped (
+	pk_skipped INTEGER NOT NULL IDENTITY, 
+	type VARCHAR(1000) NULL, 
+	message VARCHAR(1000) NULL, 
+	value VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_skipped PRIMARY KEY CLUSTERED (pk_skipped), 
+	CONSTRAINT skipped_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE properties (
+	pk_properties INTEGER NOT NULL IDENTITY, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_properties PRIMARY KEY CLUSTERED (pk_properties), 
+	CONSTRAINT properties_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE properties_property (
+	fk_properties INTEGER NOT NULL, 
+	fk_property INTEGER NOT NULL, 
+	FOREIGN KEY(fk_properties) REFERENCES properties (pk_properties), 
+	FOREIGN KEY(fk_property) REFERENCES property (pk_property)
+)
+
+
+CREATE TABLE testcase (
+	pk_testcase INTEGER NOT NULL IDENTITY, 
+	classname VARCHAR(1000) NULL, 
+	name VARCHAR(1000) NULL, 
+	time VARCHAR(1000) NULL, 
+	[group] VARCHAR(1000) NULL, 
+	[system-out] VARCHAR(8000) NULL, 
+	[system-err] VARCHAR(8000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_testcase PRIMARY KEY CLUSTERED (pk_testcase), 
+	CONSTRAINT testcase_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE testcase_skipped (
+	fk_testcase INTEGER NOT NULL, 
+	fk_skipped INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_skipped) REFERENCES skipped (pk_skipped)
+)
+
+
+CREATE TABLE testcase_error (
+	fk_testcase INTEGER NOT NULL, 
+	fk_error INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_error) REFERENCES error (pk_error)
+)
+
+
+CREATE TABLE testcase_failure (
+	fk_testcase INTEGER NOT NULL, 
+	fk_failure INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_failure) REFERENCES failure (pk_failure)
+)
+
+
+CREATE TABLE [testcase_rerunFailure_flakyError] (
+	fk_testcase INTEGER NOT NULL, 
+	[fk_flakyError] INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY([fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError])
+)
+
+
+CREATE TABLE [testcase_rerunError_flakyError] (
+	fk_testcase INTEGER NOT NULL, 
+	[fk_flakyError] INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY([fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError])
+)
+
+
+CREATE TABLE [testcase_flakyFailure_flakyError] (
+	fk_testcase INTEGER NOT NULL, 
+	[fk_flakyError] INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY([fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError])
+)
+
+
+CREATE TABLE [testcase_flakyError] (
+	fk_testcase INTEGER NOT NULL, 
+	[fk_flakyError] INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY([fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError])
+)
+
+
+CREATE TABLE testsuite (
+	pk_testsuite INTEGER NOT NULL IDENTITY, 
+	name VARCHAR(1000) NULL, 
+	errors VARCHAR(1000) NULL, 
+	failures VARCHAR(1000) NULL, 
+	skipped VARCHAR(1000) NULL, 
+	tests VARCHAR(1000) NULL, 
+	[group] VARCHAR(1000) NULL, 
+	time VARCHAR(1000) NULL, 
+	timestamp VARCHAR(1000) NULL, 
+	hostname VARCHAR(1000) NULL, 
+	id VARCHAR(1000) NULL, 
+	package VARCHAR(1000) NULL, 
+	[file] VARCHAR(1000) NULL, 
+	log VARCHAR(1000) NULL, 
+	url VARCHAR(1000) NULL, 
+	version VARCHAR(1000) NULL, 
+	[system-out] VARCHAR(8000) NULL, 
+	[system-err] VARCHAR(8000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_testsuite PRIMARY KEY CLUSTERED (pk_testsuite), 
+	CONSTRAINT testsuite_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE testsuite_properties (
+	fk_testsuite INTEGER NOT NULL, 
+	fk_properties INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite), 
+	FOREIGN KEY(fk_properties) REFERENCES properties (pk_properties)
+)
+
+
+CREATE TABLE testsuite_testcase (
+	fk_testsuite INTEGER NOT NULL, 
+	fk_testcase INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite), 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase)
+)
+
+
+CREATE TABLE testsuites (
+	pk_testsuites INTEGER NOT NULL IDENTITY, 
+	name VARCHAR(1000) NULL, 
+	time VARCHAR(1000) NULL, 
+	tests VARCHAR(1000) NULL, 
+	failures VARCHAR(1000) NULL, 
+	errors VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_testsuites PRIMARY KEY CLUSTERED (pk_testsuites), 
+	CONSTRAINT testsuites_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE testsuites_testsuite (
+	fk_testsuites INTEGER NOT NULL, 
+	fk_testsuite INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testsuites) REFERENCES testsuites (pk_testsuites), 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite)
+)
+
+
+CREATE TABLE junit10 (
+	pk_junit10 INTEGER NOT NULL IDENTITY, 
+	fk_error INTEGER NULL, 
+	fk_failure INTEGER NULL, 
+	[fk_flakyError] INTEGER NULL, 
+	[flakyFailure_fk_flakyError] INTEGER NULL, 
+	fk_properties INTEGER NULL, 
+	fk_property INTEGER NULL, 
+	[rerunError_fk_flakyError] INTEGER NULL, 
+	[rerunFailure_fk_flakyError] INTEGER NULL, 
+	fk_skipped INTEGER NULL, 
+	[system-err] VARCHAR(1000) NULL, 
+	[system-out] VARCHAR(1000) NULL, 
+	fk_testcase INTEGER NULL, 
+	fk_testsuite INTEGER NULL, 
+	fk_testsuites INTEGER NULL, 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at DATETIMEOFFSET NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_junit10 PRIMARY KEY CLUSTERED (pk_junit10), 
+	CONSTRAINT junit10_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY(fk_error) REFERENCES error (pk_error), 
+	FOREIGN KEY(fk_failure) REFERENCES failure (pk_failure), 
+	FOREIGN KEY([fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError]), 
+	FOREIGN KEY([flakyFailure_fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError]), 
+	FOREIGN KEY(fk_properties) REFERENCES properties (pk_properties), 
+	FOREIGN KEY(fk_property) REFERENCES property (pk_property), 
+	FOREIGN KEY([rerunError_fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError]), 
+	FOREIGN KEY([rerunFailure_fk_flakyError]) REFERENCES [flakyError] ([pk_flakyError]), 
+	FOREIGN KEY(fk_skipped) REFERENCES skipped (pk_skipped), 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite), 
+	FOREIGN KEY(fk_testsuites) REFERENCES testsuites (pk_testsuites)
+)
+
+CREATE INDEX ix_properties_property_fk_property ON properties_property (fk_property)
+
+CREATE INDEX ix_testcase_skipped_fk_skipped ON testcase_skipped (fk_skipped)
+
+CREATE INDEX ix_testcase_error_fk_error ON testcase_error (fk_error)
+
+CREATE INDEX ix_testcase_failure_fk_failure ON testcase_failure (fk_failure)
+
+CREATE INDEX [ix_testcase_rerunFailure_flakyError_fk_flakyError] ON [testcase_rerunFailure_flakyError] ([fk_flakyError])
+
+CREATE INDEX [ix_testcase_rerunError_flakyError_fk_flakyError] ON [testcase_rerunError_flakyError] ([fk_flakyError])
+
+CREATE INDEX [ix_testcase_flakyFailure_flakyError_fk_flakyError] ON [testcase_flakyFailure_flakyError] ([fk_flakyError])
+
+CREATE INDEX [ix_testcase_flakyError_fk_flakyError] ON [testcase_flakyError] ([fk_flakyError])
+
+CREATE INDEX ix_testsuite_properties_fk_properties ON testsuite_properties (fk_properties)
+
+CREATE INDEX ix_testsuite_testcase_fk_testcase ON testsuite_testcase (fk_testcase)
+
+CREATE INDEX ix_testsuites_testsuite_fk_testsuite ON testsuites_testsuite (fk_testsuite)
+
+CREATE INDEX ix_junit10_fk_error ON junit10 (fk_error)
+
+CREATE INDEX ix_junit10_fk_failure ON junit10 (fk_failure)
+
+CREATE INDEX [ix_junit10_fk_flakyError] ON junit10 ([fk_flakyError])
+
+CREATE INDEX ix_junit10_fk_properties ON junit10 (fk_properties)
+
+CREATE INDEX ix_junit10_fk_property ON junit10 (fk_property)
+
+CREATE INDEX ix_junit10_fk_skipped ON junit10 (fk_skipped)
+
+CREATE INDEX ix_junit10_fk_testcase ON junit10 (fk_testcase)
+
+CREATE INDEX ix_junit10_fk_testsuite ON junit10 (fk_testsuite)
+
+CREATE INDEX ix_junit10_fk_testsuites ON junit10 (fk_testsuites)
+
+CREATE INDEX [ix_junit10_flakyFailure_fk_flakyError] ON junit10 ([flakyFailure_fk_flakyError])
+
+CREATE INDEX [ix_junit10_rerunError_fk_flakyError] ON junit10 ([rerunError_fk_flakyError])
+
+CREATE INDEX [ix_junit10_rerunFailure_fk_flakyError] ON junit10 ([rerunFailure_fk_flakyError])
+

--- a/tests/sample_models/junit10/junit10_ddl_postgresql_version0.sql
+++ b/tests/sample_models/junit10/junit10_ddl_postgresql_version0.sql
@@ -1,0 +1,275 @@
+
+CREATE TABLE error (
+	pk_error SERIAL NOT NULL, 
+	type VARCHAR(1000), 
+	message VARCHAR(1000), 
+	value VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_error PRIMARY KEY (pk_error), 
+	CONSTRAINT error_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE failure (
+	pk_failure SERIAL NOT NULL, 
+	type VARCHAR(1000), 
+	message VARCHAR(1000), 
+	value VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_failure PRIMARY KEY (pk_failure), 
+	CONSTRAINT failure_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE property (
+	pk_property SERIAL NOT NULL, 
+	name VARCHAR(1000), 
+	value VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_property PRIMARY KEY (pk_property), 
+	CONSTRAINT property_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "flakyError" (
+	"pk_flakyError" SERIAL NOT NULL, 
+	message VARCHAR(1000), 
+	type VARCHAR(1000), 
+	"stackTrace" VARCHAR(1000), 
+	"system-out" VARCHAR(1000), 
+	"system-err" VARCHAR(1000), 
+	value VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_flakyError" PRIMARY KEY ("pk_flakyError"), 
+	CONSTRAINT "flakyError_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE skipped (
+	pk_skipped SERIAL NOT NULL, 
+	type VARCHAR(1000), 
+	message VARCHAR(1000), 
+	value VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_skipped PRIMARY KEY (pk_skipped), 
+	CONSTRAINT skipped_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE properties (
+	pk_properties SERIAL NOT NULL, 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_properties PRIMARY KEY (pk_properties), 
+	CONSTRAINT properties_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE properties_property (
+	fk_properties INTEGER NOT NULL, 
+	fk_property INTEGER NOT NULL, 
+	FOREIGN KEY(fk_properties) REFERENCES properties (pk_properties), 
+	FOREIGN KEY(fk_property) REFERENCES property (pk_property)
+)
+
+
+CREATE TABLE testcase (
+	pk_testcase SERIAL NOT NULL, 
+	classname VARCHAR(1000), 
+	name VARCHAR(1000), 
+	time VARCHAR(1000), 
+	"group" VARCHAR(1000), 
+	"system-out" VARCHAR(8000), 
+	"system-err" VARCHAR(8000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_testcase PRIMARY KEY (pk_testcase), 
+	CONSTRAINT testcase_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE testcase_skipped (
+	fk_testcase INTEGER NOT NULL, 
+	fk_skipped INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_skipped) REFERENCES skipped (pk_skipped)
+)
+
+
+CREATE TABLE testcase_error (
+	fk_testcase INTEGER NOT NULL, 
+	fk_error INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_error) REFERENCES error (pk_error)
+)
+
+
+CREATE TABLE testcase_failure (
+	fk_testcase INTEGER NOT NULL, 
+	fk_failure INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_failure) REFERENCES failure (pk_failure)
+)
+
+
+CREATE TABLE "testcase_rerunFailure_flakyError" (
+	fk_testcase INTEGER NOT NULL, 
+	"fk_flakyError" INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY("fk_flakyError") REFERENCES "flakyError" ("pk_flakyError")
+)
+
+
+CREATE TABLE "testcase_rerunError_flakyError" (
+	fk_testcase INTEGER NOT NULL, 
+	"fk_flakyError" INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY("fk_flakyError") REFERENCES "flakyError" ("pk_flakyError")
+)
+
+
+CREATE TABLE "testcase_flakyFailure_flakyError" (
+	fk_testcase INTEGER NOT NULL, 
+	"fk_flakyError" INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY("fk_flakyError") REFERENCES "flakyError" ("pk_flakyError")
+)
+
+
+CREATE TABLE "testcase_flakyError" (
+	fk_testcase INTEGER NOT NULL, 
+	"fk_flakyError" INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY("fk_flakyError") REFERENCES "flakyError" ("pk_flakyError")
+)
+
+
+CREATE TABLE testsuite (
+	pk_testsuite SERIAL NOT NULL, 
+	name VARCHAR(1000), 
+	errors VARCHAR(1000), 
+	failures VARCHAR(1000), 
+	skipped VARCHAR(1000), 
+	tests VARCHAR(1000), 
+	"group" VARCHAR(1000), 
+	time VARCHAR(1000), 
+	timestamp VARCHAR(1000), 
+	hostname VARCHAR(1000), 
+	id VARCHAR(1000), 
+	package VARCHAR(1000), 
+	file VARCHAR(1000), 
+	log VARCHAR(1000), 
+	url VARCHAR(1000), 
+	version VARCHAR(1000), 
+	"system-out" VARCHAR(8000), 
+	"system-err" VARCHAR(8000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_testsuite PRIMARY KEY (pk_testsuite), 
+	CONSTRAINT testsuite_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE testsuite_properties (
+	fk_testsuite INTEGER NOT NULL, 
+	fk_properties INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite), 
+	FOREIGN KEY(fk_properties) REFERENCES properties (pk_properties)
+)
+
+
+CREATE TABLE testsuite_testcase (
+	fk_testsuite INTEGER NOT NULL, 
+	fk_testcase INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite), 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase)
+)
+
+
+CREATE TABLE junit10 (
+	pk_junit10 SERIAL NOT NULL, 
+	fk_error INTEGER, 
+	fk_failure INTEGER, 
+	"fk_flakyError" INTEGER, 
+	"flakyFailure_fk_flakyError" INTEGER, 
+	fk_properties INTEGER, 
+	fk_property INTEGER, 
+	"rerunError_fk_flakyError" INTEGER, 
+	"rerunFailure_fk_flakyError" INTEGER, 
+	fk_skipped INTEGER, 
+	"system-err" VARCHAR(1000), 
+	"system-out" VARCHAR(1000), 
+	fk_testcase INTEGER, 
+	fk_testsuite INTEGER, 
+	testsuites_name VARCHAR(1000), 
+	testsuites_time VARCHAR(1000), 
+	testsuites_tests VARCHAR(1000), 
+	testsuites_failures VARCHAR(1000), 
+	testsuites_errors VARCHAR(1000), 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at TIMESTAMP WITH TIME ZONE, 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_junit10 PRIMARY KEY (pk_junit10), 
+	CONSTRAINT junit10_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY(fk_error) REFERENCES error (pk_error), 
+	FOREIGN KEY(fk_failure) REFERENCES failure (pk_failure), 
+	FOREIGN KEY("fk_flakyError") REFERENCES "flakyError" ("pk_flakyError"), 
+	FOREIGN KEY("flakyFailure_fk_flakyError") REFERENCES "flakyError" ("pk_flakyError"), 
+	FOREIGN KEY(fk_properties) REFERENCES properties (pk_properties), 
+	FOREIGN KEY(fk_property) REFERENCES property (pk_property), 
+	FOREIGN KEY("rerunError_fk_flakyError") REFERENCES "flakyError" ("pk_flakyError"), 
+	FOREIGN KEY("rerunFailure_fk_flakyError") REFERENCES "flakyError" ("pk_flakyError"), 
+	FOREIGN KEY(fk_skipped) REFERENCES skipped (pk_skipped), 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite)
+)
+
+
+CREATE TABLE junit10_testsuite (
+	fk_junit10 INTEGER NOT NULL, 
+	fk_testsuite INTEGER NOT NULL, 
+	FOREIGN KEY(fk_junit10) REFERENCES junit10 (pk_junit10), 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite)
+)
+
+CREATE INDEX ix_properties_property_fk_property ON properties_property (fk_property)
+
+CREATE INDEX ix_testcase_skipped_fk_skipped ON testcase_skipped (fk_skipped)
+
+CREATE INDEX ix_testcase_error_fk_error ON testcase_error (fk_error)
+
+CREATE INDEX ix_testcase_failure_fk_failure ON testcase_failure (fk_failure)
+
+CREATE INDEX "ix_testcase_rerunFailure_flakyError_fk_flakyError" ON "testcase_rerunFailure_flakyError" ("fk_flakyError")
+
+CREATE INDEX "ix_testcase_rerunError_flakyError_fk_flakyError" ON "testcase_rerunError_flakyError" ("fk_flakyError")
+
+CREATE INDEX "ix_testcase_flakyFailure_flakyError_fk_flakyError" ON "testcase_flakyFailure_flakyError" ("fk_flakyError")
+
+CREATE INDEX "ix_testcase_flakyError_fk_flakyError" ON "testcase_flakyError" ("fk_flakyError")
+
+CREATE INDEX ix_testsuite_properties_fk_properties ON testsuite_properties (fk_properties)
+
+CREATE INDEX ix_testsuite_testcase_fk_testcase ON testsuite_testcase (fk_testcase)
+
+CREATE INDEX ix_junit10_fk_error ON junit10 (fk_error)
+
+CREATE INDEX ix_junit10_fk_failure ON junit10 (fk_failure)
+
+CREATE INDEX "ix_junit10_fk_flakyError" ON junit10 ("fk_flakyError")
+
+CREATE INDEX ix_junit10_fk_properties ON junit10 (fk_properties)
+
+CREATE INDEX ix_junit10_fk_property ON junit10 (fk_property)
+
+CREATE INDEX ix_junit10_fk_skipped ON junit10 (fk_skipped)
+
+CREATE INDEX ix_junit10_fk_testcase ON junit10 (fk_testcase)
+
+CREATE INDEX ix_junit10_fk_testsuite ON junit10 (fk_testsuite)
+
+CREATE INDEX "ix_junit10_flakyFailure_fk_flakyError" ON junit10 ("flakyFailure_fk_flakyError")
+
+CREATE INDEX "ix_junit10_rerunError_fk_flakyError" ON junit10 ("rerunError_fk_flakyError")
+
+CREATE INDEX "ix_junit10_rerunFailure_fk_flakyError" ON junit10 ("rerunFailure_fk_flakyError")
+
+CREATE INDEX ix_junit10_testsuite_fk_testsuite ON junit10_testsuite (fk_testsuite)
+

--- a/tests/sample_models/junit10/junit10_ddl_postgresql_version1.sql
+++ b/tests/sample_models/junit10/junit10_ddl_postgresql_version1.sql
@@ -1,0 +1,287 @@
+
+CREATE TABLE error (
+	pk_error SERIAL NOT NULL, 
+	type VARCHAR(1000), 
+	message VARCHAR(1000), 
+	value VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_error PRIMARY KEY (pk_error), 
+	CONSTRAINT error_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE failure (
+	pk_failure SERIAL NOT NULL, 
+	type VARCHAR(1000), 
+	message VARCHAR(1000), 
+	value VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_failure PRIMARY KEY (pk_failure), 
+	CONSTRAINT failure_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE property (
+	pk_property SERIAL NOT NULL, 
+	name VARCHAR(1000), 
+	value VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_property PRIMARY KEY (pk_property), 
+	CONSTRAINT property_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "flakyError" (
+	"pk_flakyError" SERIAL NOT NULL, 
+	message VARCHAR(1000), 
+	type VARCHAR(1000), 
+	"stackTrace" VARCHAR(1000), 
+	"system-out" VARCHAR(1000), 
+	"system-err" VARCHAR(1000), 
+	value VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_flakyError" PRIMARY KEY ("pk_flakyError"), 
+	CONSTRAINT "flakyError_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE skipped (
+	pk_skipped SERIAL NOT NULL, 
+	type VARCHAR(1000), 
+	message VARCHAR(1000), 
+	value VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_skipped PRIMARY KEY (pk_skipped), 
+	CONSTRAINT skipped_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE properties (
+	pk_properties SERIAL NOT NULL, 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_properties PRIMARY KEY (pk_properties), 
+	CONSTRAINT properties_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE properties_property (
+	fk_properties INTEGER NOT NULL, 
+	fk_property INTEGER NOT NULL, 
+	FOREIGN KEY(fk_properties) REFERENCES properties (pk_properties), 
+	FOREIGN KEY(fk_property) REFERENCES property (pk_property)
+)
+
+
+CREATE TABLE testcase (
+	pk_testcase SERIAL NOT NULL, 
+	classname VARCHAR(1000), 
+	name VARCHAR(1000), 
+	time VARCHAR(1000), 
+	"group" VARCHAR(1000), 
+	"system-out" VARCHAR(8000), 
+	"system-err" VARCHAR(8000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_testcase PRIMARY KEY (pk_testcase), 
+	CONSTRAINT testcase_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE testcase_skipped (
+	fk_testcase INTEGER NOT NULL, 
+	fk_skipped INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_skipped) REFERENCES skipped (pk_skipped)
+)
+
+
+CREATE TABLE testcase_error (
+	fk_testcase INTEGER NOT NULL, 
+	fk_error INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_error) REFERENCES error (pk_error)
+)
+
+
+CREATE TABLE testcase_failure (
+	fk_testcase INTEGER NOT NULL, 
+	fk_failure INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_failure) REFERENCES failure (pk_failure)
+)
+
+
+CREATE TABLE "testcase_rerunFailure_flakyError" (
+	fk_testcase INTEGER NOT NULL, 
+	"fk_flakyError" INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY("fk_flakyError") REFERENCES "flakyError" ("pk_flakyError")
+)
+
+
+CREATE TABLE "testcase_rerunError_flakyError" (
+	fk_testcase INTEGER NOT NULL, 
+	"fk_flakyError" INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY("fk_flakyError") REFERENCES "flakyError" ("pk_flakyError")
+)
+
+
+CREATE TABLE "testcase_flakyFailure_flakyError" (
+	fk_testcase INTEGER NOT NULL, 
+	"fk_flakyError" INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY("fk_flakyError") REFERENCES "flakyError" ("pk_flakyError")
+)
+
+
+CREATE TABLE "testcase_flakyError" (
+	fk_testcase INTEGER NOT NULL, 
+	"fk_flakyError" INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY("fk_flakyError") REFERENCES "flakyError" ("pk_flakyError")
+)
+
+
+CREATE TABLE testsuite (
+	pk_testsuite SERIAL NOT NULL, 
+	name VARCHAR(1000), 
+	errors VARCHAR(1000), 
+	failures VARCHAR(1000), 
+	skipped VARCHAR(1000), 
+	tests VARCHAR(1000), 
+	"group" VARCHAR(1000), 
+	time VARCHAR(1000), 
+	timestamp VARCHAR(1000), 
+	hostname VARCHAR(1000), 
+	id VARCHAR(1000), 
+	package VARCHAR(1000), 
+	file VARCHAR(1000), 
+	log VARCHAR(1000), 
+	url VARCHAR(1000), 
+	version VARCHAR(1000), 
+	"system-out" VARCHAR(8000), 
+	"system-err" VARCHAR(8000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_testsuite PRIMARY KEY (pk_testsuite), 
+	CONSTRAINT testsuite_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE testsuite_properties (
+	fk_testsuite INTEGER NOT NULL, 
+	fk_properties INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite), 
+	FOREIGN KEY(fk_properties) REFERENCES properties (pk_properties)
+)
+
+
+CREATE TABLE testsuite_testcase (
+	fk_testsuite INTEGER NOT NULL, 
+	fk_testcase INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite), 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase)
+)
+
+
+CREATE TABLE testsuites (
+	pk_testsuites SERIAL NOT NULL, 
+	name VARCHAR(1000), 
+	time VARCHAR(1000), 
+	tests VARCHAR(1000), 
+	failures VARCHAR(1000), 
+	errors VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_testsuites PRIMARY KEY (pk_testsuites), 
+	CONSTRAINT testsuites_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE testsuites_testsuite (
+	fk_testsuites INTEGER NOT NULL, 
+	fk_testsuite INTEGER NOT NULL, 
+	FOREIGN KEY(fk_testsuites) REFERENCES testsuites (pk_testsuites), 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite)
+)
+
+
+CREATE TABLE junit10 (
+	pk_junit10 SERIAL NOT NULL, 
+	fk_error INTEGER, 
+	fk_failure INTEGER, 
+	"fk_flakyError" INTEGER, 
+	"flakyFailure_fk_flakyError" INTEGER, 
+	fk_properties INTEGER, 
+	fk_property INTEGER, 
+	"rerunError_fk_flakyError" INTEGER, 
+	"rerunFailure_fk_flakyError" INTEGER, 
+	fk_skipped INTEGER, 
+	"system-err" VARCHAR(1000), 
+	"system-out" VARCHAR(1000), 
+	fk_testcase INTEGER, 
+	fk_testsuite INTEGER, 
+	fk_testsuites INTEGER, 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at TIMESTAMP WITH TIME ZONE, 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_junit10 PRIMARY KEY (pk_junit10), 
+	CONSTRAINT junit10_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY(fk_error) REFERENCES error (pk_error), 
+	FOREIGN KEY(fk_failure) REFERENCES failure (pk_failure), 
+	FOREIGN KEY("fk_flakyError") REFERENCES "flakyError" ("pk_flakyError"), 
+	FOREIGN KEY("flakyFailure_fk_flakyError") REFERENCES "flakyError" ("pk_flakyError"), 
+	FOREIGN KEY(fk_properties) REFERENCES properties (pk_properties), 
+	FOREIGN KEY(fk_property) REFERENCES property (pk_property), 
+	FOREIGN KEY("rerunError_fk_flakyError") REFERENCES "flakyError" ("pk_flakyError"), 
+	FOREIGN KEY("rerunFailure_fk_flakyError") REFERENCES "flakyError" ("pk_flakyError"), 
+	FOREIGN KEY(fk_skipped) REFERENCES skipped (pk_skipped), 
+	FOREIGN KEY(fk_testcase) REFERENCES testcase (pk_testcase), 
+	FOREIGN KEY(fk_testsuite) REFERENCES testsuite (pk_testsuite), 
+	FOREIGN KEY(fk_testsuites) REFERENCES testsuites (pk_testsuites)
+)
+
+CREATE INDEX ix_properties_property_fk_property ON properties_property (fk_property)
+
+CREATE INDEX ix_testcase_skipped_fk_skipped ON testcase_skipped (fk_skipped)
+
+CREATE INDEX ix_testcase_error_fk_error ON testcase_error (fk_error)
+
+CREATE INDEX ix_testcase_failure_fk_failure ON testcase_failure (fk_failure)
+
+CREATE INDEX "ix_testcase_rerunFailure_flakyError_fk_flakyError" ON "testcase_rerunFailure_flakyError" ("fk_flakyError")
+
+CREATE INDEX "ix_testcase_rerunError_flakyError_fk_flakyError" ON "testcase_rerunError_flakyError" ("fk_flakyError")
+
+CREATE INDEX "ix_testcase_flakyFailure_flakyError_fk_flakyError" ON "testcase_flakyFailure_flakyError" ("fk_flakyError")
+
+CREATE INDEX "ix_testcase_flakyError_fk_flakyError" ON "testcase_flakyError" ("fk_flakyError")
+
+CREATE INDEX ix_testsuite_properties_fk_properties ON testsuite_properties (fk_properties)
+
+CREATE INDEX ix_testsuite_testcase_fk_testcase ON testsuite_testcase (fk_testcase)
+
+CREATE INDEX ix_testsuites_testsuite_fk_testsuite ON testsuites_testsuite (fk_testsuite)
+
+CREATE INDEX ix_junit10_fk_error ON junit10 (fk_error)
+
+CREATE INDEX ix_junit10_fk_failure ON junit10 (fk_failure)
+
+CREATE INDEX "ix_junit10_fk_flakyError" ON junit10 ("fk_flakyError")
+
+CREATE INDEX ix_junit10_fk_properties ON junit10 (fk_properties)
+
+CREATE INDEX ix_junit10_fk_property ON junit10 (fk_property)
+
+CREATE INDEX ix_junit10_fk_skipped ON junit10 (fk_skipped)
+
+CREATE INDEX ix_junit10_fk_testcase ON junit10 (fk_testcase)
+
+CREATE INDEX ix_junit10_fk_testsuite ON junit10 (fk_testsuite)
+
+CREATE INDEX ix_junit10_fk_testsuites ON junit10 (fk_testsuites)
+
+CREATE INDEX "ix_junit10_flakyFailure_fk_flakyError" ON junit10 ("flakyFailure_fk_flakyError")
+
+CREATE INDEX "ix_junit10_rerunError_fk_flakyError" ON junit10 ("rerunError_fk_flakyError")
+
+CREATE INDEX "ix_junit10_rerunFailure_fk_flakyError" ON junit10 ("rerunFailure_fk_flakyError")
+

--- a/tests/sample_models/junit10/junit10_erd_version0.md
+++ b/tests/sample_models/junit10/junit10_erd_version0.md
@@ -1,0 +1,90 @@
+```mermaid
+erDiagram
+    junit10 ||--|| error : "error"
+    junit10 ||--|| failure : "failure"
+    junit10 ||--|| flakyError : "flakyError"
+    junit10 ||--|| flakyError : "flakyFailure"
+    junit10 ||--|| properties : "properties"
+    junit10 ||--|| property : "property"
+    junit10 ||--|| flakyError : "rerunError"
+    junit10 ||--|| flakyError : "rerunFailure"
+    junit10 ||--|| skipped : "skipped"
+    junit10 ||--|| testcase : "testcase"
+    junit10 ||--|| testsuite : "testsuite"
+    junit10 ||--o{ testsuite : "testsuites_testsuite*"
+    junit10 {
+        string system-err
+        string system-out
+        string testsuites_name
+        string testsuites_time
+        string testsuites_tests
+        string testsuites_failures
+        string testsuites_errors
+    }
+    testsuite ||--o{ properties : "properties*"
+    testsuite ||--o{ testcase : "testcase*"
+    testsuite {
+        string name
+        string errors
+        string failures
+        string skipped
+        string tests
+        string group
+        string time
+        string timestamp
+        string hostname
+        string id
+        string package
+        string file
+        string log
+        string url
+        string version
+        string-N system-out
+        string-N system-err
+    }
+    testcase ||--o{ skipped : "skipped*"
+    testcase ||--o{ error : "error*"
+    testcase ||--o{ failure : "failure*"
+    testcase ||--o{ flakyError : "rerunFailure*"
+    testcase ||--o{ flakyError : "rerunError*"
+    testcase ||--o{ flakyError : "flakyFailure*"
+    testcase ||--o{ flakyError : "flakyError*"
+    testcase {
+        string classname
+        string name
+        string time
+        string group
+        string-N system-out
+        string-N system-err
+    }
+    properties ||--o{ property : "property*"
+    properties {
+    }
+    skipped {
+        string type
+        string message
+        string value
+    }
+    flakyError {
+        string message
+        string type
+        string stackTrace
+        string system-out
+        string system-err
+        string value
+    }
+    property {
+        string name
+        string value
+    }
+    failure {
+        string type
+        string message
+        string value
+    }
+    error {
+        string type
+        string message
+        string value
+    }
+```

--- a/tests/sample_models/junit10/junit10_erd_version1.md
+++ b/tests/sample_models/junit10/junit10_erd_version1.md
@@ -1,0 +1,93 @@
+```mermaid
+erDiagram
+    junit10 ||--|| error : "error"
+    junit10 ||--|| failure : "failure"
+    junit10 ||--|| flakyError : "flakyError"
+    junit10 ||--|| flakyError : "flakyFailure"
+    junit10 ||--|| properties : "properties"
+    junit10 ||--|| property : "property"
+    junit10 ||--|| flakyError : "rerunError"
+    junit10 ||--|| flakyError : "rerunFailure"
+    junit10 ||--|| skipped : "skipped"
+    junit10 ||--|| testcase : "testcase"
+    junit10 ||--|| testsuite : "testsuite"
+    junit10 ||--|| testsuites : "testsuites"
+    junit10 {
+        string system-err
+        string system-out
+    }
+    testsuites ||--o{ testsuite : "testsuite*"
+    testsuites {
+        string name
+        string time
+        string tests
+        string failures
+        string errors
+    }
+    testsuite ||--o{ properties : "properties*"
+    testsuite ||--o{ testcase : "testcase*"
+    testsuite {
+        string name
+        string errors
+        string failures
+        string skipped
+        string tests
+        string group
+        string time
+        string timestamp
+        string hostname
+        string id
+        string package
+        string file
+        string log
+        string url
+        string version
+        string-N system-out
+        string-N system-err
+    }
+    testcase ||--o{ skipped : "skipped*"
+    testcase ||--o{ error : "error*"
+    testcase ||--o{ failure : "failure*"
+    testcase ||--o{ flakyError : "rerunFailure*"
+    testcase ||--o{ flakyError : "rerunError*"
+    testcase ||--o{ flakyError : "flakyFailure*"
+    testcase ||--o{ flakyError : "flakyError*"
+    testcase {
+        string classname
+        string name
+        string time
+        string group
+        string-N system-out
+        string-N system-err
+    }
+    properties ||--o{ property : "property*"
+    properties {
+    }
+    skipped {
+        string type
+        string message
+        string value
+    }
+    flakyError {
+        string message
+        string type
+        string stackTrace
+        string system-out
+        string system-err
+        string value
+    }
+    property {
+        string name
+        string value
+    }
+    failure {
+        string type
+        string message
+        string value
+    }
+    error {
+        string type
+        string message
+        string value
+    }
+```

--- a/tests/sample_models/orders/orders_ddl_mssql_version0.sql
+++ b/tests/sample_models/orders/orders_ddl_mssql_version0.sql
@@ -1,0 +1,79 @@
+
+CREATE TABLE orderperson (
+	pk_orderperson INTEGER NOT NULL IDENTITY, 
+	name VARCHAR(1000) NULL, 
+	address VARCHAR(1000) NULL, 
+	city VARCHAR(1000) NULL, 
+	[zip_codingSystem] VARCHAR(1000) NULL, 
+	zip_value VARCHAR(1000) NULL, 
+	country VARCHAR(1000) NULL, 
+	[phoneNumber] VARCHAR(8000) NULL, 
+	[companyId_type] VARCHAR(3) NULL, 
+	[companyId_value] VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_orderperson PRIMARY KEY CLUSTERED (pk_orderperson), 
+	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE item (
+	pk_item INTEGER NOT NULL IDENTITY, 
+	product_name VARCHAR(1000) NULL, 
+	product_version VARCHAR(1000) NULL, 
+	note VARCHAR(1000) NULL, 
+	quantity INTEGER NULL, 
+	price FLOAT NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_item PRIMARY KEY CLUSTERED (pk_item), 
+	CONSTRAINT item_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE shiporder (
+	pk_shiporder INTEGER NOT NULL IDENTITY, 
+	orderid VARCHAR(1000) NULL, 
+	processed_at DATETIMEOFFSET NULL, 
+	fk_orderperson INTEGER NULL, 
+	shipto_fk_orderperson INTEGER NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_shiporder PRIMARY KEY CLUSTERED (pk_shiporder), 
+	CONSTRAINT shiporder_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY(fk_orderperson) REFERENCES orderperson (pk_orderperson), 
+	FOREIGN KEY(shipto_fk_orderperson) REFERENCES orderperson (pk_orderperson)
+)
+
+
+CREATE TABLE shiporder_item (
+	fk_shiporder INTEGER NOT NULL, 
+	fk_item INTEGER NOT NULL, 
+	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder), 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item)
+)
+
+
+CREATE TABLE orders (
+	pk_orders INTEGER NOT NULL IDENTITY, 
+	batch_id VARCHAR(1000) NULL, 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at DATETIMEOFFSET NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_orders PRIMARY KEY CLUSTERED (pk_orders), 
+	CONSTRAINT orders_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE orders_shiporder (
+	fk_orders INTEGER NOT NULL, 
+	fk_shiporder INTEGER NOT NULL, 
+	FOREIGN KEY(fk_orders) REFERENCES orders (pk_orders), 
+	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder)
+)
+
+CREATE INDEX ix_shiporder_fk_orderperson ON shiporder (fk_orderperson)
+
+CREATE INDEX ix_shiporder_shipto_fk_orderperson ON shiporder (shipto_fk_orderperson)
+
+CREATE INDEX ix_shiporder_item_fk_item ON shiporder_item (fk_item)
+
+CREATE INDEX ix_orders_shiporder_fk_shiporder ON orders_shiporder (fk_shiporder)
+

--- a/tests/sample_models/orders/orders_ddl_mssql_version1.sql
+++ b/tests/sample_models/orders/orders_ddl_mssql_version1.sql
@@ -1,0 +1,74 @@
+
+CREATE TABLE orderperson (
+	pk_orderperson INTEGER NOT NULL IDENTITY, 
+	name VARCHAR(1000) NULL, 
+	address VARCHAR(1000) NULL, 
+	city VARCHAR(1000) NULL, 
+	[zip_codingSystem] VARCHAR(1000) NULL, 
+	zip_value VARCHAR(1000) NULL, 
+	country VARCHAR(1000) NULL, 
+	[phoneNumber] VARCHAR(8000) NULL, 
+	[companyId_ace] VARCHAR(1000) NULL, 
+	[companyId_bic] VARCHAR(1000) NULL, 
+	[companyId_lei] VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_orderperson PRIMARY KEY CLUSTERED (pk_orderperson), 
+	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE shiporder (
+	pk_shiporder INTEGER NOT NULL IDENTITY, 
+	orderid VARCHAR(1000) NULL, 
+	processed_at DATETIMEOFFSET NULL, 
+	fk_orderperson INTEGER NULL, 
+	shipto_fk_orderperson INTEGER NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_shiporder PRIMARY KEY CLUSTERED (pk_shiporder), 
+	CONSTRAINT shiporder_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY(fk_orderperson) REFERENCES orderperson (pk_orderperson), 
+	FOREIGN KEY(shipto_fk_orderperson) REFERENCES orderperson (pk_orderperson)
+)
+
+
+CREATE TABLE orders (
+	pk_orders INTEGER NOT NULL IDENTITY, 
+	batch_id VARCHAR(1000) NULL, 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at DATETIMEOFFSET NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_orders PRIMARY KEY CLUSTERED (pk_orders), 
+	CONSTRAINT orders_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE orders_shiporder (
+	fk_orders INTEGER NOT NULL, 
+	fk_shiporder INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_orders) REFERENCES orders (pk_orders), 
+	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder)
+)
+
+
+CREATE TABLE item (
+	pk_item INTEGER NOT NULL IDENTITY, 
+	fk_parent_shiporder INTEGER NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	product_name VARCHAR(1000) NULL, 
+	product_version VARCHAR(1000) NULL, 
+	note VARCHAR(1000) NULL, 
+	quantity INTEGER NULL, 
+	price FLOAT NULL, 
+	CONSTRAINT cx_pk_item PRIMARY KEY CLUSTERED (pk_item), 
+	FOREIGN KEY(fk_parent_shiporder) REFERENCES shiporder (pk_shiporder)
+)
+
+CREATE INDEX ix_shiporder_fk_orderperson ON shiporder (fk_orderperson)
+
+CREATE INDEX ix_shiporder_shipto_fk_orderperson ON shiporder (shipto_fk_orderperson)
+
+CREATE INDEX ix_orders_shiporder_fk_shiporder ON orders_shiporder (fk_shiporder)
+
+CREATE INDEX ix_item_fk_parent_shiporder ON item (fk_parent_shiporder)
+

--- a/tests/sample_models/orders/orders_ddl_mssql_version2.sql
+++ b/tests/sample_models/orders/orders_ddl_mssql_version2.sql
@@ -1,0 +1,89 @@
+
+CREATE TABLE orders (
+	pk_orders INTEGER NOT NULL IDENTITY, 
+	batch_id VARCHAR(1000) NULL, 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at DATETIMEOFFSET NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_orders PRIMARY KEY CLUSTERED (pk_orders), 
+	CONSTRAINT orders_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE orderperson (
+	pk_orderperson INTEGER NOT NULL IDENTITY, 
+	name VARCHAR(1000) NULL, 
+	address VARCHAR(1000) NULL, 
+	city VARCHAR(1000) NULL, 
+	[zip_codingSystem] VARCHAR(1000) NULL, 
+	zip_value VARCHAR(1000) NULL, 
+	country VARCHAR(1000) NULL, 
+	[phoneNumber] VARCHAR(8000) NULL, 
+	[companyId_type] VARCHAR(3) NULL, 
+	[companyId_value] VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_orderperson PRIMARY KEY CLUSTERED (pk_orderperson), 
+	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE product (
+	pk_product INTEGER NOT NULL IDENTITY, 
+	name VARCHAR(1000) NULL, 
+	version VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_product PRIMARY KEY CLUSTERED (pk_product), 
+	CONSTRAINT product_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE item (
+	pk_item INTEGER NOT NULL IDENTITY, 
+	fk_product INTEGER NULL, 
+	note VARCHAR(1000) NULL, 
+	quantity INTEGER NULL, 
+	price FLOAT NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_item PRIMARY KEY CLUSTERED (pk_item), 
+	CONSTRAINT item_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY(fk_product) REFERENCES product (pk_product)
+)
+
+
+CREATE TABLE shiporder (
+	pk_shiporder INTEGER NOT NULL IDENTITY, 
+	temp_pk_shiporder INTEGER NULL, 
+	fk_parent_orders INTEGER NULL, 
+	orderid VARCHAR(1000) NULL, 
+	processed_at DATETIMEOFFSET NULL, 
+	orderperson_name VARCHAR(1000) NULL, 
+	orderperson_address VARCHAR(1000) NULL, 
+	orderperson_city VARCHAR(1000) NULL, 
+	[orderperson_zip_codingSystem] VARCHAR(1000) NULL, 
+	orderperson_zip_value VARCHAR(1000) NULL, 
+	orderperson_country VARCHAR(1000) NULL, 
+	[orderperson_phoneNumber] VARCHAR(8000) NULL, 
+	[orderperson_companyId_type] VARCHAR(3) NULL, 
+	[orderperson_companyId_value] VARCHAR(1000) NULL, 
+	shipto_fk_orderperson INTEGER NULL, 
+	CONSTRAINT cx_pk_shiporder PRIMARY KEY CLUSTERED (pk_shiporder), 
+	FOREIGN KEY(fk_parent_orders) REFERENCES orders (pk_orders), 
+	FOREIGN KEY(shipto_fk_orderperson) REFERENCES orderperson (pk_orderperson)
+)
+
+
+CREATE TABLE shiporder_item (
+	fk_shiporder INTEGER NOT NULL, 
+	fk_item INTEGER NOT NULL, 
+	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder), 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item)
+)
+
+CREATE INDEX ix_item_fk_product ON item (fk_product)
+
+CREATE INDEX ix_shiporder_fk_parent_orders ON shiporder (fk_parent_orders)
+
+CREATE INDEX ix_shiporder_shipto_fk_orderperson ON shiporder (shipto_fk_orderperson)
+
+CREATE INDEX ix_shiporder_item_fk_item ON shiporder_item (fk_item)
+

--- a/tests/sample_models/orders/orders_ddl_postgresql_version0.sql
+++ b/tests/sample_models/orders/orders_ddl_postgresql_version0.sql
@@ -1,0 +1,79 @@
+
+CREATE TABLE orderperson (
+	pk_orderperson SERIAL NOT NULL, 
+	name VARCHAR(1000), 
+	address VARCHAR(1000), 
+	city VARCHAR(1000), 
+	"zip_codingSystem" VARCHAR(1000), 
+	zip_value VARCHAR(1000), 
+	country VARCHAR(1000), 
+	"phoneNumber" VARCHAR(8000), 
+	"companyId_type" VARCHAR(3), 
+	"companyId_value" VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_orderperson PRIMARY KEY (pk_orderperson), 
+	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE item (
+	pk_item SERIAL NOT NULL, 
+	product_name VARCHAR(1000), 
+	product_version VARCHAR(1000), 
+	note VARCHAR(1000), 
+	quantity INTEGER, 
+	price FLOAT, 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_item PRIMARY KEY (pk_item), 
+	CONSTRAINT item_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE shiporder (
+	pk_shiporder SERIAL NOT NULL, 
+	orderid VARCHAR(1000), 
+	processed_at TIMESTAMP WITH TIME ZONE, 
+	fk_orderperson INTEGER, 
+	shipto_fk_orderperson INTEGER, 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_shiporder PRIMARY KEY (pk_shiporder), 
+	CONSTRAINT shiporder_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY(fk_orderperson) REFERENCES orderperson (pk_orderperson), 
+	FOREIGN KEY(shipto_fk_orderperson) REFERENCES orderperson (pk_orderperson)
+)
+
+
+CREATE TABLE shiporder_item (
+	fk_shiporder INTEGER NOT NULL, 
+	fk_item INTEGER NOT NULL, 
+	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder), 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item)
+)
+
+
+CREATE TABLE orders (
+	pk_orders SERIAL NOT NULL, 
+	batch_id VARCHAR(1000), 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at TIMESTAMP WITH TIME ZONE, 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_orders PRIMARY KEY (pk_orders), 
+	CONSTRAINT orders_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE orders_shiporder (
+	fk_orders INTEGER NOT NULL, 
+	fk_shiporder INTEGER NOT NULL, 
+	FOREIGN KEY(fk_orders) REFERENCES orders (pk_orders), 
+	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder)
+)
+
+CREATE INDEX ix_shiporder_fk_orderperson ON shiporder (fk_orderperson)
+
+CREATE INDEX ix_shiporder_shipto_fk_orderperson ON shiporder (shipto_fk_orderperson)
+
+CREATE INDEX ix_shiporder_item_fk_item ON shiporder_item (fk_item)
+
+CREATE INDEX ix_orders_shiporder_fk_shiporder ON orders_shiporder (fk_shiporder)
+

--- a/tests/sample_models/orders/orders_ddl_postgresql_version1.sql
+++ b/tests/sample_models/orders/orders_ddl_postgresql_version1.sql
@@ -1,0 +1,74 @@
+
+CREATE TABLE orderperson (
+	pk_orderperson SERIAL NOT NULL, 
+	name VARCHAR(1000), 
+	address VARCHAR(1000), 
+	city VARCHAR(1000), 
+	"zip_codingSystem" VARCHAR(1000), 
+	zip_value VARCHAR(1000), 
+	country VARCHAR(1000), 
+	"phoneNumber" VARCHAR(8000), 
+	"companyId_ace" VARCHAR(1000), 
+	"companyId_bic" VARCHAR(1000), 
+	"companyId_lei" VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_orderperson PRIMARY KEY (pk_orderperson), 
+	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE shiporder (
+	pk_shiporder SERIAL NOT NULL, 
+	orderid VARCHAR(1000), 
+	processed_at TIMESTAMP WITH TIME ZONE, 
+	fk_orderperson INTEGER, 
+	shipto_fk_orderperson INTEGER, 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_shiporder PRIMARY KEY (pk_shiporder), 
+	CONSTRAINT shiporder_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY(fk_orderperson) REFERENCES orderperson (pk_orderperson), 
+	FOREIGN KEY(shipto_fk_orderperson) REFERENCES orderperson (pk_orderperson)
+)
+
+
+CREATE TABLE orders (
+	pk_orders SERIAL NOT NULL, 
+	batch_id VARCHAR(1000), 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at TIMESTAMP WITH TIME ZONE, 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_orders PRIMARY KEY (pk_orders), 
+	CONSTRAINT orders_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE orders_shiporder (
+	fk_orders INTEGER NOT NULL, 
+	fk_shiporder INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_orders) REFERENCES orders (pk_orders), 
+	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder)
+)
+
+
+CREATE TABLE item (
+	pk_item SERIAL NOT NULL, 
+	fk_parent_shiporder INTEGER, 
+	xml2db_row_number INTEGER NOT NULL, 
+	product_name VARCHAR(1000), 
+	product_version VARCHAR(1000), 
+	note VARCHAR(1000), 
+	quantity INTEGER, 
+	price FLOAT, 
+	CONSTRAINT cx_pk_item PRIMARY KEY (pk_item), 
+	FOREIGN KEY(fk_parent_shiporder) REFERENCES shiporder (pk_shiporder)
+)
+
+CREATE INDEX ix_shiporder_fk_orderperson ON shiporder (fk_orderperson)
+
+CREATE INDEX ix_shiporder_shipto_fk_orderperson ON shiporder (shipto_fk_orderperson)
+
+CREATE INDEX ix_orders_shiporder_fk_shiporder ON orders_shiporder (fk_shiporder)
+
+CREATE INDEX ix_item_fk_parent_shiporder ON item (fk_parent_shiporder)
+

--- a/tests/sample_models/orders/orders_ddl_postgresql_version2.sql
+++ b/tests/sample_models/orders/orders_ddl_postgresql_version2.sql
@@ -1,0 +1,89 @@
+
+CREATE TABLE orders (
+	pk_orders SERIAL NOT NULL, 
+	batch_id VARCHAR(1000), 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at TIMESTAMP WITH TIME ZONE, 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_orders PRIMARY KEY (pk_orders), 
+	CONSTRAINT orders_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE orderperson (
+	pk_orderperson SERIAL NOT NULL, 
+	name VARCHAR(1000), 
+	address VARCHAR(1000), 
+	city VARCHAR(1000), 
+	"zip_codingSystem" VARCHAR(1000), 
+	zip_value VARCHAR(1000), 
+	country VARCHAR(1000), 
+	"phoneNumber" VARCHAR(8000), 
+	"companyId_type" VARCHAR(3), 
+	"companyId_value" VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_orderperson PRIMARY KEY (pk_orderperson), 
+	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE product (
+	pk_product SERIAL NOT NULL, 
+	name VARCHAR(1000), 
+	version VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_product PRIMARY KEY (pk_product), 
+	CONSTRAINT product_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE item (
+	pk_item SERIAL NOT NULL, 
+	fk_product INTEGER, 
+	note VARCHAR(1000), 
+	quantity INTEGER, 
+	price FLOAT, 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_item PRIMARY KEY (pk_item), 
+	CONSTRAINT item_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY(fk_product) REFERENCES product (pk_product)
+)
+
+
+CREATE TABLE shiporder (
+	pk_shiporder SERIAL NOT NULL, 
+	temp_pk_shiporder INTEGER, 
+	fk_parent_orders INTEGER, 
+	orderid VARCHAR(1000), 
+	processed_at TIMESTAMP WITH TIME ZONE, 
+	orderperson_name VARCHAR(1000), 
+	orderperson_address VARCHAR(1000), 
+	orderperson_city VARCHAR(1000), 
+	"orderperson_zip_codingSystem" VARCHAR(1000), 
+	orderperson_zip_value VARCHAR(1000), 
+	orderperson_country VARCHAR(1000), 
+	"orderperson_phoneNumber" VARCHAR(8000), 
+	"orderperson_companyId_type" VARCHAR(3), 
+	"orderperson_companyId_value" VARCHAR(1000), 
+	shipto_fk_orderperson INTEGER, 
+	CONSTRAINT cx_pk_shiporder PRIMARY KEY (pk_shiporder), 
+	FOREIGN KEY(fk_parent_orders) REFERENCES orders (pk_orders), 
+	FOREIGN KEY(shipto_fk_orderperson) REFERENCES orderperson (pk_orderperson)
+)
+
+
+CREATE TABLE shiporder_item (
+	fk_shiporder INTEGER NOT NULL, 
+	fk_item INTEGER NOT NULL, 
+	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder), 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item)
+)
+
+CREATE INDEX ix_item_fk_product ON item (fk_product)
+
+CREATE INDEX ix_shiporder_fk_parent_orders ON shiporder (fk_parent_orders)
+
+CREATE INDEX ix_shiporder_shipto_fk_orderperson ON shiporder (shipto_fk_orderperson)
+
+CREATE INDEX ix_shiporder_item_fk_item ON shiporder_item (fk_item)
+

--- a/tests/sample_models/orders/orders_erd_version0.md
+++ b/tests/sample_models/orders/orders_erd_version0.md
@@ -1,0 +1,32 @@
+```mermaid
+erDiagram
+    orders ||--o{ shiporder : "shiporder*"
+    orders {
+        string batch_id
+    }
+    shiporder ||--|| orderperson : "orderperson"
+    shiporder ||--o| orderperson : "shipto"
+    shiporder ||--|{ item : "item*"
+    shiporder {
+        string orderid
+        dateTime processed_at
+    }
+    item {
+        string product_name
+        string product_version
+        string note
+        integer quantity
+        decimal price
+    }
+    orderperson {
+        string name
+        string address
+        string city
+        string zip_codingSystem
+        string zip_value
+        string country
+        string-N phoneNumber
+        string companyId_type
+        string companyId_value
+    }
+```

--- a/tests/sample_models/orders/orders_erd_version1.md
+++ b/tests/sample_models/orders/orders_erd_version1.md
@@ -1,0 +1,33 @@
+```mermaid
+erDiagram
+    item {
+        string product_name
+        string product_version
+        string note
+        integer quantity
+        decimal price
+    }
+    orders ||--o{ shiporder : "shiporder*"
+    orders {
+        string batch_id
+    }
+    shiporder ||--|| orderperson : "orderperson"
+    shiporder ||--o| orderperson : "shipto"
+    shiporder ||--|{ item : "item"
+    shiporder {
+        string orderid
+        dateTime processed_at
+    }
+    orderperson {
+        string name
+        string address
+        string city
+        string zip_codingSystem
+        string zip_value
+        string country
+        string-N phoneNumber
+        string companyId_ace
+        string companyId_bic
+        string companyId_lei
+    }
+```

--- a/tests/sample_models/orders/orders_erd_version2.md
+++ b/tests/sample_models/orders/orders_erd_version2.md
@@ -1,0 +1,43 @@
+```mermaid
+erDiagram
+    shiporder ||--o| orderperson : "shipto"
+    shiporder ||--|{ item : "item*"
+    shiporder {
+        string orderid
+        dateTime processed_at
+        string orderperson_name
+        string orderperson_address
+        string orderperson_city
+        string orderperson_zip_codingSystem
+        string orderperson_zip_value
+        string orderperson_country
+        string-N orderperson_phoneNumber
+        string orderperson_companyId_type
+        string orderperson_companyId_value
+    }
+    item ||--|| product : "product"
+    item {
+        string note
+        integer quantity
+        decimal price
+    }
+    product {
+        string name
+        string version
+    }
+    orderperson {
+        string name
+        string address
+        string city
+        string zip_codingSystem
+        string zip_value
+        string country
+        string-N phoneNumber
+        string companyId_type
+        string companyId_value
+    }
+    orders ||--o{ shiporder : "shiporder"
+    orders {
+        string batch_id
+    }
+```

--- a/tests/sample_models/table1/table1_ddl_mssql_version0.sql
+++ b/tests/sample_models/table1/table1_ddl_mssql_version0.sql
@@ -1,0 +1,344 @@
+
+CREATE TABLE [contractTradingHours] (
+	[pk_contractTradingHours] INTEGER NOT NULL IDENTITY, 
+	[startTime] VARCHAR(18) NULL, 
+	[endTime] VARCHAR(18) NULL, 
+	date VARCHAR(16) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_contractTradingHours] PRIMARY KEY CLUSTERED ([pk_contractTradingHours]), 
+	CONSTRAINT [contractTradingHours_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [deliveryProfile] (
+	[pk_deliveryProfile] INTEGER NOT NULL IDENTITY, 
+	[loadDeliveryStartDate] VARCHAR(16) NULL, 
+	[loadDeliveryEndDate] VARCHAR(16) NULL, 
+	[daysOfTheWeek] VARCHAR(8000) NULL, 
+	[loadDeliveryStartTime] VARCHAR(8000) NULL, 
+	[loadDeliveryEndTime] VARCHAR(8000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_deliveryProfile] PRIMARY KEY CLUSTERED ([pk_deliveryProfile]), 
+	CONSTRAINT [deliveryProfile_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [fixingIndex] (
+	[pk_fixingIndex] INTEGER NOT NULL IDENTITY, 
+	[indexName] VARCHAR(150) NULL, 
+	[indexValue] FLOAT NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_fixingIndex] PRIMARY KEY CLUSTERED ([pk_fixingIndex]), 
+	CONSTRAINT [fixingIndex_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [optionDetails] (
+	[pk_optionDetails] INTEGER NOT NULL IDENTITY, 
+	[optionStyle] VARCHAR(1) NULL, 
+	[optionType] VARCHAR(1) NULL, 
+	[optionExerciseDate] VARCHAR(8000) NULL, 
+	[optionStrikePrice_value] FLOAT NULL, 
+	[optionStrikePrice_currency] VARCHAR(3) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_optionDetails] PRIMARY KEY CLUSTERED ([pk_optionDetails]), 
+	CONSTRAINT [optionDetails_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [legContractId] (
+	[pk_legContractId] INTEGER NOT NULL IDENTITY, 
+	[contractId] VARCHAR(50) NULL, 
+	[buySellIndicator] VARCHAR(1) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_legContractId] PRIMARY KEY CLUSTERED ([pk_legContractId]), 
+	CONSTRAINT [legContractId_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [priceIntervalQuantityDetails] (
+	[pk_priceIntervalQuantityDetails] INTEGER NOT NULL IDENTITY, 
+	[intervalStartDate] VARCHAR(16) NULL, 
+	[intervalEndDate] VARCHAR(16) NULL, 
+	[daysOfTheWeek] VARCHAR(1000) NULL, 
+	[intervalStartTime] VARCHAR(8000) NULL, 
+	[intervalEndTime] VARCHAR(8000) NULL, 
+	quantity FLOAT NULL, 
+	unit VARCHAR(8) NULL, 
+	[priceTimeIntervalQuantity_value] FLOAT NULL, 
+	[priceTimeIntervalQuantity_currency] VARCHAR(3) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_priceIntervalQuantityDetails] PRIMARY KEY CLUSTERED ([pk_priceIntervalQuantityDetails]), 
+	CONSTRAINT [priceIntervalQuantityDetails_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [clickAndTradeDetails] (
+	[pk_clickAndTradeDetails] INTEGER NOT NULL IDENTITY, 
+	[orderType] VARCHAR(3) NULL, 
+	[orderCondition] VARCHAR(8000) NULL, 
+	[orderStatus] VARCHAR(8000) NULL, 
+	[minimumExecuteVolume_value] FLOAT NULL, 
+	[minimumExecuteVolume_unit] VARCHAR(8) NULL, 
+	[triggerDetails_priceLimit_value] FLOAT NULL, 
+	[triggerDetails_priceLimit_currency] VARCHAR(3) NULL, 
+	[triggerDetails_triggerContractId] VARCHAR(50) NULL, 
+	[undisclosedVolume_value] FLOAT NULL, 
+	[undisclosedVolume_unit] VARCHAR(8) NULL, 
+	[orderDuration_duration] VARCHAR(3) NULL, 
+	[orderDuration_expirationDateTime] DATETIMEOFFSET NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_clickAndTradeDetails] PRIMARY KEY CLUSTERED ([pk_clickAndTradeDetails]), 
+	CONSTRAINT [clickAndTradeDetails_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE contract (
+	pk_contract INTEGER NOT NULL IDENTITY, 
+	[contractId] VARCHAR(50) NULL, 
+	[contractName] VARCHAR(200) NULL, 
+	[contractType] VARCHAR(5) NULL, 
+	[energyCommodity] VARCHAR(8000) NULL, 
+	[settlementMethod] VARCHAR(1) NULL, 
+	[organisedMarketPlaceIdentifier_type] VARCHAR(3) NULL, 
+	[organisedMarketPlaceIdentifier_value] VARCHAR(20) NULL, 
+	[lastTradingDateTime] DATETIMEOFFSET NULL, 
+	[fk_optionDetails] INTEGER NULL, 
+	[deliveryPointOrZone] VARCHAR(8000) NULL, 
+	[deliveryStartDate] VARCHAR(16) NULL, 
+	[deliveryEndDate] VARCHAR(16) NULL, 
+	duration VARCHAR(1) NULL, 
+	[loadType] VARCHAR(2) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_contract PRIMARY KEY CLUSTERED (pk_contract), 
+	CONSTRAINT contract_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY([fk_optionDetails]) REFERENCES [optionDetails] ([pk_optionDetails])
+)
+
+
+CREATE TABLE [contract_fixingIndex] (
+	fk_contract INTEGER NOT NULL, 
+	[fk_fixingIndex] INTEGER NOT NULL, 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract), 
+	FOREIGN KEY([fk_fixingIndex]) REFERENCES [fixingIndex] ([pk_fixingIndex])
+)
+
+
+CREATE TABLE [contract_contractTradingHours] (
+	fk_contract INTEGER NOT NULL, 
+	[fk_contractTradingHours] INTEGER NOT NULL, 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract), 
+	FOREIGN KEY([fk_contractTradingHours]) REFERENCES [contractTradingHours] ([pk_contractTradingHours])
+)
+
+
+CREATE TABLE [contract_deliveryProfile] (
+	fk_contract INTEGER NOT NULL, 
+	[fk_deliveryProfile] INTEGER NOT NULL, 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract), 
+	FOREIGN KEY([fk_deliveryProfile]) REFERENCES [deliveryProfile] ([pk_deliveryProfile])
+)
+
+
+CREATE TABLE [legContract] (
+	[pk_legContract] INTEGER NOT NULL IDENTITY, 
+	fk_contract INTEGER NULL, 
+	[buySellIndicator] VARCHAR(1) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_legContract] PRIMARY KEY CLUSTERED ([pk_legContract]), 
+	CONSTRAINT [legContract_xml2db_record_hash] UNIQUE (record_hash), 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE [TradeReport] (
+	[pk_TradeReport] INTEGER NOT NULL IDENTITY, 
+	[RecordSeqNumber] INTEGER NULL, 
+	[idOfMarketParticipant_type] VARCHAR(3) NULL, 
+	[idOfMarketParticipant_value] VARCHAR(20) NULL, 
+	[traderID_traderIdForOrganisedMarket] VARCHAR(100) NULL, 
+	[traderID_traderIdForMarketParticipant] VARCHAR(100) NULL, 
+	[otherMarketParticipant_type] VARCHAR(3) NULL, 
+	[otherMarketParticipant_value] VARCHAR(20) NULL, 
+	[beneficiaryIdentification_type] VARCHAR(3) NULL, 
+	[beneficiaryIdentification_value] VARCHAR(20) NULL, 
+	[tradingCapacity] VARCHAR(1) NULL, 
+	[buySellIndicator] VARCHAR(1) NULL, 
+	aggressor VARCHAR(1) NULL, 
+	[fk_clickAndTradeDetails] INTEGER NULL, 
+	[contractInfo_contractId] VARCHAR(50) NULL, 
+	[fk_contractInfo_contract] INTEGER NULL, 
+	[organisedMarketPlaceIdentifier_type] VARCHAR(3) NULL, 
+	[organisedMarketPlaceIdentifier_value] VARCHAR(20) NULL, 
+	[transactionTime] DATETIMEOFFSET NULL, 
+	[executionTime] DATETIMEOFFSET NULL, 
+	[uniqueTransactionIdentifier_uniqueTransactionIdentifier] VARCHAR(100) NULL, 
+	[uniqueTransactionIdentifier_additionalUtiInfo] VARCHAR(100) NULL, 
+	[linkedTransactionId] VARCHAR(8000) NULL, 
+	[linkedOrderId] VARCHAR(8000) NULL, 
+	[voiceBrokered] VARCHAR(1000) NULL, 
+	[priceDetails_price] FLOAT NULL, 
+	[priceDetails_priceCurrency] VARCHAR(3) NULL, 
+	[notionalAmountDetails_notionalAmount] FLOAT NULL, 
+	[notionalAmountDetails_notionalCurrency] VARCHAR(3) NULL, 
+	quantity_value FLOAT NULL, 
+	quantity_unit VARCHAR(8) NULL, 
+	[totalNotionalContractQuantity_value] FLOAT NULL, 
+	[totalNotionalContractQuantity_unit] VARCHAR(6) NULL, 
+	[terminationDate] DATETIMEOFFSET NULL, 
+	[actionType] VARCHAR(1) NULL, 
+	[Extra] VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_TradeReport] PRIMARY KEY CLUSTERED ([pk_TradeReport]), 
+	CONSTRAINT [TradeReport_xml2db_record_hash] UNIQUE (record_hash), 
+	FOREIGN KEY([fk_clickAndTradeDetails]) REFERENCES [clickAndTradeDetails] ([pk_clickAndTradeDetails]), 
+	FOREIGN KEY([fk_contractInfo_contract]) REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE [TradeReport_priceIntervalQuantityDetails] (
+	[fk_TradeReport] INTEGER NOT NULL, 
+	[fk_priceIntervalQuantityDetails] INTEGER NOT NULL, 
+	FOREIGN KEY([fk_TradeReport]) REFERENCES [TradeReport] ([pk_TradeReport]), 
+	FOREIGN KEY([fk_priceIntervalQuantityDetails]) REFERENCES [priceIntervalQuantityDetails] ([pk_priceIntervalQuantityDetails])
+)
+
+
+CREATE TABLE [OrderReport] (
+	[pk_OrderReport] INTEGER NOT NULL IDENTITY, 
+	[RecordSeqNumber] INTEGER NULL, 
+	[idOfMarketParticipant_type] VARCHAR(3) NULL, 
+	[idOfMarketParticipant_value] VARCHAR(20) NULL, 
+	[traderID_traderIdForOrganisedMarket] VARCHAR(100) NULL, 
+	[traderID_traderIdForMarketParticipant] VARCHAR(100) NULL, 
+	[beneficiaryIdentification_type] VARCHAR(3) NULL, 
+	[beneficiaryIdentification_value] VARCHAR(20) NULL, 
+	[tradingCapacity] VARCHAR(1) NULL, 
+	[buySellIndicator] VARCHAR(1) NULL, 
+	[orderId_uniqueOrderIdentifier] VARCHAR(100) NULL, 
+	[orderId_previousOrderIdentifier] VARCHAR(100) NULL, 
+	[orderType] VARCHAR(3) NULL, 
+	[orderCondition] VARCHAR(8000) NULL, 
+	[orderStatus] VARCHAR(8000) NULL, 
+	[minimumExecuteVolume_value] FLOAT NULL, 
+	[minimumExecuteVolume_unit] VARCHAR(8) NULL, 
+	[triggerDetails_priceLimit_value] FLOAT NULL, 
+	[triggerDetails_priceLimit_currency] VARCHAR(3) NULL, 
+	[triggerDetails_triggerContractId] VARCHAR(50) NULL, 
+	[undisclosedVolume_value] FLOAT NULL, 
+	[undisclosedVolume_unit] VARCHAR(8) NULL, 
+	[orderDuration_duration] VARCHAR(3) NULL, 
+	[orderDuration_expirationDateTime] DATETIMEOFFSET NULL, 
+	[contractInfo_contractId] VARCHAR(50) NULL, 
+	[fk_contractInfo_contract] INTEGER NULL, 
+	[organisedMarketPlaceIdentifier_type] VARCHAR(3) NULL, 
+	[organisedMarketPlaceIdentifier_value] VARCHAR(20) NULL, 
+	[transactionTime] DATETIMEOFFSET NULL, 
+	[originalEntryTime] DATETIMEOFFSET NULL, 
+	[linkedOrderId] VARCHAR(8000) NULL, 
+	[priceDetails_price] FLOAT NULL, 
+	[priceDetails_priceCurrency] VARCHAR(3) NULL, 
+	[notionalAmountDetails_notionalAmount] FLOAT NULL, 
+	[notionalAmountDetails_notionalCurrency] VARCHAR(3) NULL, 
+	quantity_value FLOAT NULL, 
+	quantity_unit VARCHAR(8) NULL, 
+	[totalNotionalContractQuantity_value] FLOAT NULL, 
+	[totalNotionalContractQuantity_unit] VARCHAR(6) NULL, 
+	[actionType] VARCHAR(1) NULL, 
+	[Extra] VARCHAR(1000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_OrderReport] PRIMARY KEY CLUSTERED ([pk_OrderReport]), 
+	CONSTRAINT [OrderReport_xml2db_record_hash] UNIQUE (record_hash), 
+	FOREIGN KEY([fk_contractInfo_contract]) REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE [OrderReport_priceIntervalQuantityDetails] (
+	[fk_OrderReport] INTEGER NOT NULL, 
+	[fk_priceIntervalQuantityDetails] INTEGER NOT NULL, 
+	FOREIGN KEY([fk_OrderReport]) REFERENCES [OrderReport] ([pk_OrderReport]), 
+	FOREIGN KEY([fk_priceIntervalQuantityDetails]) REFERENCES [priceIntervalQuantityDetails] ([pk_priceIntervalQuantityDetails])
+)
+
+
+CREATE TABLE [OrderReport_legContractId] (
+	[fk_OrderReport] INTEGER NOT NULL, 
+	[fk_legContractId] INTEGER NOT NULL, 
+	FOREIGN KEY([fk_OrderReport]) REFERENCES [OrderReport] ([pk_OrderReport]), 
+	FOREIGN KEY([fk_legContractId]) REFERENCES [legContractId] ([pk_legContractId])
+)
+
+
+CREATE TABLE [OrderReport_legContract] (
+	[fk_OrderReport] INTEGER NOT NULL, 
+	[fk_legContract] INTEGER NOT NULL, 
+	FOREIGN KEY([fk_OrderReport]) REFERENCES [OrderReport] ([pk_OrderReport]), 
+	FOREIGN KEY([fk_legContract]) REFERENCES [legContract] ([pk_legContract])
+)
+
+
+CREATE TABLE [REMITTable1] (
+	[pk_REMITTable1] INTEGER NOT NULL IDENTITY, 
+	[reportingEntityID_type] VARCHAR(3) NULL, 
+	[reportingEntityID_value] VARCHAR(20) NULL, 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at DATETIMEOFFSET NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_REMITTable1] PRIMARY KEY CLUSTERED ([pk_REMITTable1]), 
+	CONSTRAINT [REMITTable1_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [REMITTable1_contract] (
+	[fk_REMITTable1] INTEGER NOT NULL, 
+	fk_contract INTEGER NOT NULL, 
+	FOREIGN KEY([fk_REMITTable1]) REFERENCES [REMITTable1] ([pk_REMITTable1]), 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE [REMITTable1_OrderReport] (
+	[fk_REMITTable1] INTEGER NOT NULL, 
+	[fk_OrderReport] INTEGER NOT NULL, 
+	FOREIGN KEY([fk_REMITTable1]) REFERENCES [REMITTable1] ([pk_REMITTable1]), 
+	FOREIGN KEY([fk_OrderReport]) REFERENCES [OrderReport] ([pk_OrderReport])
+)
+
+
+CREATE TABLE [REMITTable1_TradeReport] (
+	[fk_REMITTable1] INTEGER NOT NULL, 
+	[fk_TradeReport] INTEGER NOT NULL, 
+	FOREIGN KEY([fk_REMITTable1]) REFERENCES [REMITTable1] ([pk_REMITTable1]), 
+	FOREIGN KEY([fk_TradeReport]) REFERENCES [TradeReport] ([pk_TradeReport])
+)
+
+CREATE INDEX [ix_contract_fk_optionDetails] ON contract ([fk_optionDetails])
+
+CREATE INDEX [ix_contract_fixingIndex_fk_fixingIndex] ON [contract_fixingIndex] ([fk_fixingIndex])
+
+CREATE INDEX [ix_contract_contractTradingHours_fk_contractTradingHours] ON [contract_contractTradingHours] ([fk_contractTradingHours])
+
+CREATE INDEX [ix_contract_deliveryProfile_fk_deliveryProfile] ON [contract_deliveryProfile] ([fk_deliveryProfile])
+
+CREATE INDEX [ix_legContract_fk_contract] ON [legContract] (fk_contract)
+
+CREATE INDEX [ix_TradeReport_fk_clickAndTradeDetails] ON [TradeReport] ([fk_clickAndTradeDetails])
+
+CREATE INDEX [ix_TradeReport_fk_contractInfo_contract] ON [TradeReport] ([fk_contractInfo_contract])
+
+CREATE INDEX [ix_TradeReport_priceIntervalQuantityDetails_fk_priceIntervalQuantityDetails] ON [TradeReport_priceIntervalQuantityDetails] ([fk_priceIntervalQuantityDetails])
+
+CREATE INDEX [ix_OrderReport_fk_contractInfo_contract] ON [OrderReport] ([fk_contractInfo_contract])
+
+CREATE INDEX [ix_OrderReport_priceIntervalQuantityDetails_fk_priceIntervalQuantityDetails] ON [OrderReport_priceIntervalQuantityDetails] ([fk_priceIntervalQuantityDetails])
+
+CREATE INDEX [ix_OrderReport_legContractId_fk_legContractId] ON [OrderReport_legContractId] ([fk_legContractId])
+
+CREATE INDEX [ix_OrderReport_legContract_fk_legContract] ON [OrderReport_legContract] ([fk_legContract])
+
+CREATE INDEX [ix_REMITTable1_contract_fk_contract] ON [REMITTable1_contract] (fk_contract)
+
+CREATE INDEX [ix_REMITTable1_OrderReport_fk_OrderReport] ON [REMITTable1_OrderReport] ([fk_OrderReport])
+
+CREATE INDEX [ix_REMITTable1_TradeReport_fk_TradeReport] ON [REMITTable1_TradeReport] ([fk_TradeReport])
+

--- a/tests/sample_models/table1/table1_ddl_mssql_version1.sql
+++ b/tests/sample_models/table1/table1_ddl_mssql_version1.sql
@@ -1,0 +1,360 @@
+
+CREATE TABLE [contractTradingHours] (
+	[pk_contractTradingHours] INTEGER NOT NULL IDENTITY, 
+	[startTime] VARCHAR(18) NULL, 
+	[endTime] VARCHAR(18) NULL, 
+	date VARCHAR(16) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_contractTradingHours] PRIMARY KEY NONCLUSTERED ([pk_contractTradingHours]), 
+	CONSTRAINT [contractTradingHours_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [deliveryProfile] (
+	[pk_deliveryProfile] INTEGER NOT NULL IDENTITY, 
+	[loadDeliveryStartDate] VARCHAR(16) NULL, 
+	[loadDeliveryEndDate] VARCHAR(16) NULL, 
+	[daysOfTheWeek] VARCHAR(8000) NULL, 
+	[loadDeliveryStartTime] VARCHAR(8000) NULL, 
+	[loadDeliveryEndTime] VARCHAR(8000) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_deliveryProfile] PRIMARY KEY NONCLUSTERED ([pk_deliveryProfile]), 
+	CONSTRAINT [deliveryProfile_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [fixingIndex] (
+	[pk_fixingIndex] INTEGER NOT NULL IDENTITY, 
+	[indexName] VARCHAR(150) NULL, 
+	[indexValue] FLOAT NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_fixingIndex] PRIMARY KEY NONCLUSTERED ([pk_fixingIndex]), 
+	CONSTRAINT [fixingIndex_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [optionDetails] (
+	[pk_optionDetails] INTEGER NOT NULL IDENTITY, 
+	[optionStyle] VARCHAR(1) NULL, 
+	[optionType] VARCHAR(1) NULL, 
+	[optionExerciseDate] VARCHAR(8000) NULL, 
+	[optionStrikePrice_value] FLOAT NULL, 
+	[optionStrikePrice_currency] VARCHAR(3) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_optionDetails] PRIMARY KEY NONCLUSTERED ([pk_optionDetails]), 
+	CONSTRAINT [optionDetails_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [priceIntervalQuantityDetails] (
+	[pk_priceIntervalQuantityDetails] INTEGER NOT NULL IDENTITY, 
+	[intervalStartDate] VARCHAR(16) NULL, 
+	[intervalEndDate] VARCHAR(16) NULL, 
+	[daysOfTheWeek] VARCHAR(1000) NULL, 
+	[intervalStartTime] VARCHAR(8000) NULL, 
+	[intervalEndTime] VARCHAR(8000) NULL, 
+	quantity FLOAT NULL, 
+	unit VARCHAR(8) NULL, 
+	[priceTimeIntervalQuantity_value] FLOAT NULL, 
+	[priceTimeIntervalQuantity_currency] VARCHAR(3) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_priceIntervalQuantityDetails] PRIMARY KEY NONCLUSTERED ([pk_priceIntervalQuantityDetails]), 
+	CONSTRAINT [priceIntervalQuantityDetails_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [clickAndTradeDetails] (
+	[pk_clickAndTradeDetails] INTEGER NOT NULL IDENTITY, 
+	[orderType] VARCHAR(3) NULL, 
+	[orderCondition] VARCHAR(8000) NULL, 
+	[orderStatus] VARCHAR(8000) NULL, 
+	[minimumExecuteVolume_value] FLOAT NULL, 
+	[minimumExecuteVolume_unit] VARCHAR(8) NULL, 
+	[triggerDetails_priceLimit_value] FLOAT NULL, 
+	[triggerDetails_priceLimit_currency] VARCHAR(3) NULL, 
+	[triggerDetails_triggerContractId] VARCHAR(50) NULL, 
+	[undisclosedVolume_value] FLOAT NULL, 
+	[undisclosedVolume_unit] VARCHAR(8) NULL, 
+	[orderDuration_duration] VARCHAR(3) NULL, 
+	[orderDuration_expirationDateTime] DATETIMEOFFSET NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_clickAndTradeDetails] PRIMARY KEY NONCLUSTERED ([pk_clickAndTradeDetails]), 
+	CONSTRAINT [clickAndTradeDetails_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE contract (
+	pk_contract INTEGER NOT NULL IDENTITY, 
+	[contractId] VARCHAR(50) NULL, 
+	[contractName] VARCHAR(200) NULL, 
+	[contractType] VARCHAR(5) NULL, 
+	[energyCommodity] VARCHAR(8000) NULL, 
+	[settlementMethod] VARCHAR(1) NULL, 
+	[organisedMarketPlaceIdentifier_type] VARCHAR(3) NULL, 
+	[organisedMarketPlaceIdentifier_value] VARCHAR(20) NULL, 
+	[lastTradingDateTime] DATETIMEOFFSET NULL, 
+	[fk_optionDetails] INTEGER NULL, 
+	[deliveryPointOrZone] VARCHAR(8000) NULL, 
+	[deliveryStartDate] VARCHAR(16) NULL, 
+	[deliveryEndDate] VARCHAR(16) NULL, 
+	duration VARCHAR(1) NULL, 
+	[loadType] VARCHAR(2) NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT cx_pk_contract PRIMARY KEY NONCLUSTERED (pk_contract), 
+	CONSTRAINT contract_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY([fk_optionDetails]) REFERENCES [optionDetails] ([pk_optionDetails])
+)
+
+
+CREATE TABLE [contract_fixingIndex] (
+	fk_contract INTEGER NOT NULL, 
+	[fk_fixingIndex] INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract), 
+	FOREIGN KEY([fk_fixingIndex]) REFERENCES [fixingIndex] ([pk_fixingIndex])
+)
+
+
+CREATE TABLE [contract_contractTradingHours] (
+	fk_contract INTEGER NOT NULL, 
+	[fk_contractTradingHours] INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract), 
+	FOREIGN KEY([fk_contractTradingHours]) REFERENCES [contractTradingHours] ([pk_contractTradingHours])
+)
+
+
+CREATE TABLE [contract_deliveryProfile] (
+	fk_contract INTEGER NOT NULL, 
+	[fk_deliveryProfile] INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract), 
+	FOREIGN KEY([fk_deliveryProfile]) REFERENCES [deliveryProfile] ([pk_deliveryProfile])
+)
+
+
+CREATE TABLE [REMITTable1] (
+	[pk_REMITTable1] INTEGER NOT NULL IDENTITY, 
+	[reportingEntityID_type] VARCHAR(3) NULL, 
+	[reportingEntityID_value] VARCHAR(20) NULL, 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at DATETIMEOFFSET NULL, 
+	record_hash IMAGE NULL, 
+	CONSTRAINT [cx_pk_REMITTable1] PRIMARY KEY NONCLUSTERED ([pk_REMITTable1]), 
+	CONSTRAINT [REMITTable1_xml2db_record_hash] UNIQUE (record_hash)
+)
+
+
+CREATE TABLE [REMITTable1_contract] (
+	[fk_REMITTable1] INTEGER NOT NULL, 
+	fk_contract INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY([fk_REMITTable1]) REFERENCES [REMITTable1] ([pk_REMITTable1]), 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE [OrderReport] (
+	[pk_OrderReport] INTEGER NOT NULL IDENTITY, 
+	[temp_pk_OrderReport] INTEGER NULL, 
+	[fk_parent_REMITTable1] INTEGER NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	[RecordSeqNumber] INTEGER NULL, 
+	[idOfMarketParticipant_type] VARCHAR(3) NULL, 
+	[idOfMarketParticipant_value] VARCHAR(20) NULL, 
+	[traderID_traderIdForOrganisedMarket] VARCHAR(100) NULL, 
+	[traderID_traderIdForMarketParticipant] VARCHAR(100) NULL, 
+	[beneficiaryIdentification_type] VARCHAR(3) NULL, 
+	[beneficiaryIdentification_value] VARCHAR(20) NULL, 
+	[tradingCapacity] VARCHAR(1) NULL, 
+	[buySellIndicator] VARCHAR(1) NULL, 
+	[orderId_uniqueOrderIdentifier] VARCHAR(100) NULL, 
+	[orderId_previousOrderIdentifier] VARCHAR(100) NULL, 
+	[orderType] VARCHAR(3) NULL, 
+	[orderCondition] VARCHAR(8000) NULL, 
+	[orderStatus] VARCHAR(8000) NULL, 
+	[minimumExecuteVolume_value] FLOAT NULL, 
+	[minimumExecuteVolume_unit] VARCHAR(8) NULL, 
+	[triggerDetails_priceLimit_value] FLOAT NULL, 
+	[triggerDetails_priceLimit_currency] VARCHAR(3) NULL, 
+	[triggerDetails_triggerContractId] VARCHAR(50) NULL, 
+	[undisclosedVolume_value] FLOAT NULL, 
+	[undisclosedVolume_unit] VARCHAR(8) NULL, 
+	[orderDuration_duration] VARCHAR(3) NULL, 
+	[orderDuration_expirationDateTime] DATETIMEOFFSET NULL, 
+	[contractInfo_contractId] VARCHAR(50) NULL, 
+	[fk_contractInfo_contract] INTEGER NULL, 
+	[organisedMarketPlaceIdentifier_type] VARCHAR(3) NULL, 
+	[organisedMarketPlaceIdentifier_value] VARCHAR(20) NULL, 
+	[transactionTime] DATETIMEOFFSET NULL, 
+	[originalEntryTime] DATETIMEOFFSET NULL, 
+	[linkedOrderId] VARCHAR(8000) NULL, 
+	[priceDetails_price] FLOAT NULL, 
+	[priceDetails_priceCurrency] VARCHAR(3) NULL, 
+	[notionalAmountDetails_notionalAmount] FLOAT NULL, 
+	[notionalAmountDetails_notionalCurrency] VARCHAR(3) NULL, 
+	quantity_value FLOAT NULL, 
+	quantity_unit VARCHAR(8) NULL, 
+	[totalNotionalContractQuantity_value] FLOAT NULL, 
+	[totalNotionalContractQuantity_unit] VARCHAR(6) NULL, 
+	[actionType] VARCHAR(1) NULL, 
+	[Extra] VARCHAR(1000) NULL, 
+	CONSTRAINT [cx_pk_OrderReport] PRIMARY KEY NONCLUSTERED ([pk_OrderReport]), 
+	FOREIGN KEY([fk_parent_REMITTable1]) REFERENCES [REMITTable1] ([pk_REMITTable1]), 
+	FOREIGN KEY([fk_contractInfo_contract]) REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE [OrderReport_priceIntervalQuantityDetails] (
+	[fk_OrderReport] INTEGER NOT NULL, 
+	[fk_priceIntervalQuantityDetails] INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY([fk_OrderReport]) REFERENCES [OrderReport] ([pk_OrderReport]), 
+	FOREIGN KEY([fk_priceIntervalQuantityDetails]) REFERENCES [priceIntervalQuantityDetails] ([pk_priceIntervalQuantityDetails])
+)
+
+
+CREATE TABLE [TradeReport] (
+	[pk_TradeReport] INTEGER NOT NULL IDENTITY, 
+	[temp_pk_TradeReport] INTEGER NULL, 
+	[fk_parent_REMITTable1] INTEGER NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	[RecordSeqNumber] INTEGER NULL, 
+	[idOfMarketParticipant_type] VARCHAR(3) NULL, 
+	[idOfMarketParticipant_value] VARCHAR(20) NULL, 
+	[traderID_traderIdForOrganisedMarket] VARCHAR(100) NULL, 
+	[traderID_traderIdForMarketParticipant] VARCHAR(100) NULL, 
+	[otherMarketParticipant_type] VARCHAR(3) NULL, 
+	[otherMarketParticipant_value] VARCHAR(20) NULL, 
+	[beneficiaryIdentification_type] VARCHAR(3) NULL, 
+	[beneficiaryIdentification_value] VARCHAR(20) NULL, 
+	[tradingCapacity] VARCHAR(1) NULL, 
+	[buySellIndicator] VARCHAR(1) NULL, 
+	aggressor VARCHAR(1) NULL, 
+	[fk_clickAndTradeDetails] INTEGER NULL, 
+	[contractInfo_contractId] VARCHAR(50) NULL, 
+	[fk_contractInfo_contract] INTEGER NULL, 
+	[organisedMarketPlaceIdentifier_type] VARCHAR(3) NULL, 
+	[organisedMarketPlaceIdentifier_value] VARCHAR(20) NULL, 
+	[transactionTime] DATETIMEOFFSET NULL, 
+	[executionTime] DATETIMEOFFSET NULL, 
+	[uniqueTransactionIdentifier_uniqueTransactionIdentifier] VARCHAR(100) NULL, 
+	[uniqueTransactionIdentifier_additionalUtiInfo] VARCHAR(100) NULL, 
+	[linkedTransactionId] VARCHAR(8000) NULL, 
+	[linkedOrderId] VARCHAR(8000) NULL, 
+	[voiceBrokered] VARCHAR(1000) NULL, 
+	[priceDetails_price] FLOAT NULL, 
+	[priceDetails_priceCurrency] VARCHAR(3) NULL, 
+	[notionalAmountDetails_notionalAmount] FLOAT NULL, 
+	[notionalAmountDetails_notionalCurrency] VARCHAR(3) NULL, 
+	quantity_value FLOAT NULL, 
+	quantity_unit VARCHAR(8) NULL, 
+	[totalNotionalContractQuantity_value] FLOAT NULL, 
+	[totalNotionalContractQuantity_unit] VARCHAR(6) NULL, 
+	[terminationDate] DATETIMEOFFSET NULL, 
+	[actionType] VARCHAR(1) NULL, 
+	[Extra] VARCHAR(1000) NULL, 
+	CONSTRAINT [cx_pk_TradeReport] PRIMARY KEY NONCLUSTERED ([pk_TradeReport]), 
+	FOREIGN KEY([fk_parent_REMITTable1]) REFERENCES [REMITTable1] ([pk_REMITTable1]), 
+	FOREIGN KEY([fk_clickAndTradeDetails]) REFERENCES [clickAndTradeDetails] ([pk_clickAndTradeDetails]), 
+	FOREIGN KEY([fk_contractInfo_contract]) REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE [TradeReport_priceIntervalQuantityDetails] (
+	[fk_TradeReport] INTEGER NOT NULL, 
+	[fk_priceIntervalQuantityDetails] INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY([fk_TradeReport]) REFERENCES [TradeReport] ([pk_TradeReport]), 
+	FOREIGN KEY([fk_priceIntervalQuantityDetails]) REFERENCES [priceIntervalQuantityDetails] ([pk_priceIntervalQuantityDetails])
+)
+
+
+CREATE TABLE [legContractId] (
+	[pk_legContractId] INTEGER NOT NULL IDENTITY, 
+	[fk_parent_OrderReport] INTEGER NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	[contractId] VARCHAR(50) NULL, 
+	[buySellIndicator] VARCHAR(1) NULL, 
+	CONSTRAINT [cx_pk_legContractId] PRIMARY KEY NONCLUSTERED ([pk_legContractId]), 
+	FOREIGN KEY([fk_parent_OrderReport]) REFERENCES [OrderReport] ([pk_OrderReport])
+)
+
+
+CREATE TABLE [legContract] (
+	[pk_legContract] INTEGER NOT NULL IDENTITY, 
+	[fk_parent_OrderReport] INTEGER NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	fk_contract INTEGER NULL, 
+	[buySellIndicator] VARCHAR(1) NULL, 
+	CONSTRAINT [cx_pk_legContract] PRIMARY KEY NONCLUSTERED ([pk_legContract]), 
+	FOREIGN KEY([fk_parent_OrderReport]) REFERENCES [OrderReport] ([pk_OrderReport]), 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract)
+)
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_contractTradingHours_columnstore] ON [contractTradingHours]
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_deliveryProfile_columnstore] ON [deliveryProfile]
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_fixingIndex_columnstore] ON [fixingIndex]
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_optionDetails_columnstore] ON [optionDetails]
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_priceIntervalQuantityDetails_columnstore] ON [priceIntervalQuantityDetails]
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_clickAndTradeDetails_columnstore] ON [clickAndTradeDetails]
+
+CREATE CLUSTERED COLUMNSTORE INDEX idx_contract_columnstore ON contract
+
+CREATE INDEX [ix_contract_fk_optionDetails] ON contract ([fk_optionDetails])
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_contract_fixingIndex_columnstore] ON [contract_fixingIndex]
+
+CREATE INDEX [ix_contract_fixingIndex_fk_fixingIndex] ON [contract_fixingIndex] ([fk_fixingIndex])
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_contract_contractTradingHours_columnstore] ON [contract_contractTradingHours]
+
+CREATE INDEX [ix_contract_contractTradingHours_fk_contractTradingHours] ON [contract_contractTradingHours] ([fk_contractTradingHours])
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_contract_deliveryProfile_columnstore] ON [contract_deliveryProfile]
+
+CREATE INDEX [ix_contract_deliveryProfile_fk_deliveryProfile] ON [contract_deliveryProfile] ([fk_deliveryProfile])
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_REMITTable1_columnstore] ON [REMITTable1]
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_REMITTable1_contract_columnstore] ON [REMITTable1_contract]
+
+CREATE INDEX [ix_REMITTable1_contract_fk_contract] ON [REMITTable1_contract] (fk_contract)
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_OrderReport_columnstore] ON [OrderReport]
+
+CREATE INDEX [ix_OrderReport_fk_contractInfo_contract] ON [OrderReport] ([fk_contractInfo_contract])
+
+CREATE INDEX [ix_OrderReport_fk_parent_REMITTable1] ON [OrderReport] ([fk_parent_REMITTable1])
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_OrderReport_priceIntervalQuantityDetails_columnstore] ON [OrderReport_priceIntervalQuantityDetails]
+
+CREATE INDEX [ix_OrderReport_priceIntervalQuantityDetails_fk_priceIntervalQuantityDetails] ON [OrderReport_priceIntervalQuantityDetails] ([fk_priceIntervalQuantityDetails])
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_TradeReport_columnstore] ON [TradeReport]
+
+CREATE INDEX [ix_TradeReport_fk_clickAndTradeDetails] ON [TradeReport] ([fk_clickAndTradeDetails])
+
+CREATE INDEX [ix_TradeReport_fk_contractInfo_contract] ON [TradeReport] ([fk_contractInfo_contract])
+
+CREATE INDEX [ix_TradeReport_fk_parent_REMITTable1] ON [TradeReport] ([fk_parent_REMITTable1])
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_TradeReport_priceIntervalQuantityDetails_columnstore] ON [TradeReport_priceIntervalQuantityDetails]
+
+CREATE INDEX [ix_TradeReport_priceIntervalQuantityDetails_fk_priceIntervalQuantityDetails] ON [TradeReport_priceIntervalQuantityDetails] ([fk_priceIntervalQuantityDetails])
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_legContractId_columnstore] ON [legContractId]
+
+CREATE INDEX [ix_legContractId_fk_parent_OrderReport] ON [legContractId] ([fk_parent_OrderReport])
+
+CREATE CLUSTERED COLUMNSTORE INDEX [idx_legContract_columnstore] ON [legContract]
+
+CREATE INDEX [ix_legContract_fk_contract] ON [legContract] (fk_contract)
+
+CREATE INDEX [ix_legContract_fk_parent_OrderReport] ON [legContract] ([fk_parent_OrderReport])
+

--- a/tests/sample_models/table1/table1_ddl_postgresql_version0.sql
+++ b/tests/sample_models/table1/table1_ddl_postgresql_version0.sql
@@ -1,0 +1,344 @@
+
+CREATE TABLE "contractTradingHours" (
+	"pk_contractTradingHours" SERIAL NOT NULL, 
+	"startTime" VARCHAR(18), 
+	"endTime" VARCHAR(18), 
+	date VARCHAR(16), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_contractTradingHours" PRIMARY KEY ("pk_contractTradingHours"), 
+	CONSTRAINT "contractTradingHours_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "deliveryProfile" (
+	"pk_deliveryProfile" SERIAL NOT NULL, 
+	"loadDeliveryStartDate" VARCHAR(16), 
+	"loadDeliveryEndDate" VARCHAR(16), 
+	"daysOfTheWeek" VARCHAR(8000), 
+	"loadDeliveryStartTime" VARCHAR(8000), 
+	"loadDeliveryEndTime" VARCHAR(8000), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_deliveryProfile" PRIMARY KEY ("pk_deliveryProfile"), 
+	CONSTRAINT "deliveryProfile_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "fixingIndex" (
+	"pk_fixingIndex" SERIAL NOT NULL, 
+	"indexName" VARCHAR(150), 
+	"indexValue" FLOAT, 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_fixingIndex" PRIMARY KEY ("pk_fixingIndex"), 
+	CONSTRAINT "fixingIndex_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "optionDetails" (
+	"pk_optionDetails" SERIAL NOT NULL, 
+	"optionStyle" VARCHAR(1), 
+	"optionType" VARCHAR(1), 
+	"optionExerciseDate" VARCHAR(8000), 
+	"optionStrikePrice_value" FLOAT, 
+	"optionStrikePrice_currency" VARCHAR(3), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_optionDetails" PRIMARY KEY ("pk_optionDetails"), 
+	CONSTRAINT "optionDetails_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "legContractId" (
+	"pk_legContractId" SERIAL NOT NULL, 
+	"contractId" VARCHAR(50), 
+	"buySellIndicator" VARCHAR(1), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_legContractId" PRIMARY KEY ("pk_legContractId"), 
+	CONSTRAINT "legContractId_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "priceIntervalQuantityDetails" (
+	"pk_priceIntervalQuantityDetails" SERIAL NOT NULL, 
+	"intervalStartDate" VARCHAR(16), 
+	"intervalEndDate" VARCHAR(16), 
+	"daysOfTheWeek" VARCHAR(1000), 
+	"intervalStartTime" VARCHAR(8000), 
+	"intervalEndTime" VARCHAR(8000), 
+	quantity FLOAT, 
+	unit VARCHAR(8), 
+	"priceTimeIntervalQuantity_value" FLOAT, 
+	"priceTimeIntervalQuantity_currency" VARCHAR(3), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_priceIntervalQuantityDetails" PRIMARY KEY ("pk_priceIntervalQuantityDetails"), 
+	CONSTRAINT "priceIntervalQuantityDetails_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "clickAndTradeDetails" (
+	"pk_clickAndTradeDetails" SERIAL NOT NULL, 
+	"orderType" VARCHAR(3), 
+	"orderCondition" VARCHAR(8000), 
+	"orderStatus" VARCHAR(8000), 
+	"minimumExecuteVolume_value" FLOAT, 
+	"minimumExecuteVolume_unit" VARCHAR(8), 
+	"triggerDetails_priceLimit_value" FLOAT, 
+	"triggerDetails_priceLimit_currency" VARCHAR(3), 
+	"triggerDetails_triggerContractId" VARCHAR(50), 
+	"undisclosedVolume_value" FLOAT, 
+	"undisclosedVolume_unit" VARCHAR(8), 
+	"orderDuration_duration" VARCHAR(3), 
+	"orderDuration_expirationDateTime" TIMESTAMP WITH TIME ZONE, 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_clickAndTradeDetails" PRIMARY KEY ("pk_clickAndTradeDetails"), 
+	CONSTRAINT "clickAndTradeDetails_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE contract (
+	pk_contract SERIAL NOT NULL, 
+	"contractId" VARCHAR(50), 
+	"contractName" VARCHAR(200), 
+	"contractType" VARCHAR(5), 
+	"energyCommodity" VARCHAR(8000), 
+	"settlementMethod" VARCHAR(1), 
+	"organisedMarketPlaceIdentifier_type" VARCHAR(3), 
+	"organisedMarketPlaceIdentifier_value" VARCHAR(20), 
+	"lastTradingDateTime" TIMESTAMP WITH TIME ZONE, 
+	"fk_optionDetails" INTEGER, 
+	"deliveryPointOrZone" VARCHAR(8000), 
+	"deliveryStartDate" VARCHAR(16), 
+	"deliveryEndDate" VARCHAR(16), 
+	duration VARCHAR(1), 
+	"loadType" VARCHAR(2), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_contract PRIMARY KEY (pk_contract), 
+	CONSTRAINT contract_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY("fk_optionDetails") REFERENCES "optionDetails" ("pk_optionDetails")
+)
+
+
+CREATE TABLE "contract_fixingIndex" (
+	fk_contract INTEGER NOT NULL, 
+	"fk_fixingIndex" INTEGER NOT NULL, 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract), 
+	FOREIGN KEY("fk_fixingIndex") REFERENCES "fixingIndex" ("pk_fixingIndex")
+)
+
+
+CREATE TABLE "contract_contractTradingHours" (
+	fk_contract INTEGER NOT NULL, 
+	"fk_contractTradingHours" INTEGER NOT NULL, 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract), 
+	FOREIGN KEY("fk_contractTradingHours") REFERENCES "contractTradingHours" ("pk_contractTradingHours")
+)
+
+
+CREATE TABLE "contract_deliveryProfile" (
+	fk_contract INTEGER NOT NULL, 
+	"fk_deliveryProfile" INTEGER NOT NULL, 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract), 
+	FOREIGN KEY("fk_deliveryProfile") REFERENCES "deliveryProfile" ("pk_deliveryProfile")
+)
+
+
+CREATE TABLE "legContract" (
+	"pk_legContract" SERIAL NOT NULL, 
+	fk_contract INTEGER, 
+	"buySellIndicator" VARCHAR(1), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_legContract" PRIMARY KEY ("pk_legContract"), 
+	CONSTRAINT "legContract_xml2db_record_hash" UNIQUE (record_hash), 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE "TradeReport" (
+	"pk_TradeReport" SERIAL NOT NULL, 
+	"RecordSeqNumber" INTEGER, 
+	"idOfMarketParticipant_type" VARCHAR(3), 
+	"idOfMarketParticipant_value" VARCHAR(20), 
+	"traderID_traderIdForOrganisedMarket" VARCHAR(100), 
+	"traderID_traderIdForMarketParticipant" VARCHAR(100), 
+	"otherMarketParticipant_type" VARCHAR(3), 
+	"otherMarketParticipant_value" VARCHAR(20), 
+	"beneficiaryIdentification_type" VARCHAR(3), 
+	"beneficiaryIdentification_value" VARCHAR(20), 
+	"tradingCapacity" VARCHAR(1), 
+	"buySellIndicator" VARCHAR(1), 
+	aggressor VARCHAR(1), 
+	"fk_clickAndTradeDetails" INTEGER, 
+	"contractInfo_contractId" VARCHAR(50), 
+	"fk_contractInfo_contract" INTEGER, 
+	"organisedMarketPlaceIdentifier_type" VARCHAR(3), 
+	"organisedMarketPlaceIdentifier_value" VARCHAR(20), 
+	"transactionTime" TIMESTAMP WITH TIME ZONE, 
+	"executionTime" TIMESTAMP WITH TIME ZONE, 
+	"uniqueTransactionIdentifier_uniqueTransactionIdentifier" VARCHAR(100), 
+	"uniqueTransactionIdentifier_additionalUtiInfo" VARCHAR(100), 
+	"linkedTransactionId" VARCHAR(8000), 
+	"linkedOrderId" VARCHAR(8000), 
+	"voiceBrokered" VARCHAR(1000), 
+	"priceDetails_price" FLOAT, 
+	"priceDetails_priceCurrency" VARCHAR(3), 
+	"notionalAmountDetails_notionalAmount" FLOAT, 
+	"notionalAmountDetails_notionalCurrency" VARCHAR(3), 
+	quantity_value FLOAT, 
+	quantity_unit VARCHAR(8), 
+	"totalNotionalContractQuantity_value" FLOAT, 
+	"totalNotionalContractQuantity_unit" VARCHAR(6), 
+	"terminationDate" TIMESTAMP WITH TIME ZONE, 
+	"actionType" VARCHAR(1), 
+	"Extra" VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_TradeReport" PRIMARY KEY ("pk_TradeReport"), 
+	CONSTRAINT "TradeReport_xml2db_record_hash" UNIQUE (record_hash), 
+	FOREIGN KEY("fk_clickAndTradeDetails") REFERENCES "clickAndTradeDetails" ("pk_clickAndTradeDetails"), 
+	FOREIGN KEY("fk_contractInfo_contract") REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE "TradeReport_priceIntervalQuantityDetails" (
+	"fk_TradeReport" INTEGER NOT NULL, 
+	"fk_priceIntervalQuantityDetails" INTEGER NOT NULL, 
+	FOREIGN KEY("fk_TradeReport") REFERENCES "TradeReport" ("pk_TradeReport"), 
+	FOREIGN KEY("fk_priceIntervalQuantityDetails") REFERENCES "priceIntervalQuantityDetails" ("pk_priceIntervalQuantityDetails")
+)
+
+
+CREATE TABLE "OrderReport" (
+	"pk_OrderReport" SERIAL NOT NULL, 
+	"RecordSeqNumber" INTEGER, 
+	"idOfMarketParticipant_type" VARCHAR(3), 
+	"idOfMarketParticipant_value" VARCHAR(20), 
+	"traderID_traderIdForOrganisedMarket" VARCHAR(100), 
+	"traderID_traderIdForMarketParticipant" VARCHAR(100), 
+	"beneficiaryIdentification_type" VARCHAR(3), 
+	"beneficiaryIdentification_value" VARCHAR(20), 
+	"tradingCapacity" VARCHAR(1), 
+	"buySellIndicator" VARCHAR(1), 
+	"orderId_uniqueOrderIdentifier" VARCHAR(100), 
+	"orderId_previousOrderIdentifier" VARCHAR(100), 
+	"orderType" VARCHAR(3), 
+	"orderCondition" VARCHAR(8000), 
+	"orderStatus" VARCHAR(8000), 
+	"minimumExecuteVolume_value" FLOAT, 
+	"minimumExecuteVolume_unit" VARCHAR(8), 
+	"triggerDetails_priceLimit_value" FLOAT, 
+	"triggerDetails_priceLimit_currency" VARCHAR(3), 
+	"triggerDetails_triggerContractId" VARCHAR(50), 
+	"undisclosedVolume_value" FLOAT, 
+	"undisclosedVolume_unit" VARCHAR(8), 
+	"orderDuration_duration" VARCHAR(3), 
+	"orderDuration_expirationDateTime" TIMESTAMP WITH TIME ZONE, 
+	"contractInfo_contractId" VARCHAR(50), 
+	"fk_contractInfo_contract" INTEGER, 
+	"organisedMarketPlaceIdentifier_type" VARCHAR(3), 
+	"organisedMarketPlaceIdentifier_value" VARCHAR(20), 
+	"transactionTime" TIMESTAMP WITH TIME ZONE, 
+	"originalEntryTime" TIMESTAMP WITH TIME ZONE, 
+	"linkedOrderId" VARCHAR(8000), 
+	"priceDetails_price" FLOAT, 
+	"priceDetails_priceCurrency" VARCHAR(3), 
+	"notionalAmountDetails_notionalAmount" FLOAT, 
+	"notionalAmountDetails_notionalCurrency" VARCHAR(3), 
+	quantity_value FLOAT, 
+	quantity_unit VARCHAR(8), 
+	"totalNotionalContractQuantity_value" FLOAT, 
+	"totalNotionalContractQuantity_unit" VARCHAR(6), 
+	"actionType" VARCHAR(1), 
+	"Extra" VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_OrderReport" PRIMARY KEY ("pk_OrderReport"), 
+	CONSTRAINT "OrderReport_xml2db_record_hash" UNIQUE (record_hash), 
+	FOREIGN KEY("fk_contractInfo_contract") REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE "OrderReport_priceIntervalQuantityDetails" (
+	"fk_OrderReport" INTEGER NOT NULL, 
+	"fk_priceIntervalQuantityDetails" INTEGER NOT NULL, 
+	FOREIGN KEY("fk_OrderReport") REFERENCES "OrderReport" ("pk_OrderReport"), 
+	FOREIGN KEY("fk_priceIntervalQuantityDetails") REFERENCES "priceIntervalQuantityDetails" ("pk_priceIntervalQuantityDetails")
+)
+
+
+CREATE TABLE "OrderReport_legContractId" (
+	"fk_OrderReport" INTEGER NOT NULL, 
+	"fk_legContractId" INTEGER NOT NULL, 
+	FOREIGN KEY("fk_OrderReport") REFERENCES "OrderReport" ("pk_OrderReport"), 
+	FOREIGN KEY("fk_legContractId") REFERENCES "legContractId" ("pk_legContractId")
+)
+
+
+CREATE TABLE "OrderReport_legContract" (
+	"fk_OrderReport" INTEGER NOT NULL, 
+	"fk_legContract" INTEGER NOT NULL, 
+	FOREIGN KEY("fk_OrderReport") REFERENCES "OrderReport" ("pk_OrderReport"), 
+	FOREIGN KEY("fk_legContract") REFERENCES "legContract" ("pk_legContract")
+)
+
+
+CREATE TABLE "REMITTable1" (
+	"pk_REMITTable1" SERIAL NOT NULL, 
+	"reportingEntityID_type" VARCHAR(3), 
+	"reportingEntityID_value" VARCHAR(20), 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at TIMESTAMP WITH TIME ZONE, 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_REMITTable1" PRIMARY KEY ("pk_REMITTable1"), 
+	CONSTRAINT "REMITTable1_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "REMITTable1_contract" (
+	"fk_REMITTable1" INTEGER NOT NULL, 
+	fk_contract INTEGER NOT NULL, 
+	FOREIGN KEY("fk_REMITTable1") REFERENCES "REMITTable1" ("pk_REMITTable1"), 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE "REMITTable1_OrderReport" (
+	"fk_REMITTable1" INTEGER NOT NULL, 
+	"fk_OrderReport" INTEGER NOT NULL, 
+	FOREIGN KEY("fk_REMITTable1") REFERENCES "REMITTable1" ("pk_REMITTable1"), 
+	FOREIGN KEY("fk_OrderReport") REFERENCES "OrderReport" ("pk_OrderReport")
+)
+
+
+CREATE TABLE "REMITTable1_TradeReport" (
+	"fk_REMITTable1" INTEGER NOT NULL, 
+	"fk_TradeReport" INTEGER NOT NULL, 
+	FOREIGN KEY("fk_REMITTable1") REFERENCES "REMITTable1" ("pk_REMITTable1"), 
+	FOREIGN KEY("fk_TradeReport") REFERENCES "TradeReport" ("pk_TradeReport")
+)
+
+CREATE INDEX "ix_contract_fk_optionDetails" ON contract ("fk_optionDetails")
+
+CREATE INDEX "ix_contract_fixingIndex_fk_fixingIndex" ON "contract_fixingIndex" ("fk_fixingIndex")
+
+CREATE INDEX "ix_contract_contractTradingHours_fk_contractTradingHours" ON "contract_contractTradingHours" ("fk_contractTradingHours")
+
+CREATE INDEX "ix_contract_deliveryProfile_fk_deliveryProfile" ON "contract_deliveryProfile" ("fk_deliveryProfile")
+
+CREATE INDEX "ix_legContract_fk_contract" ON "legContract" (fk_contract)
+
+CREATE INDEX "ix_TradeReport_fk_clickAndTradeDetails" ON "TradeReport" ("fk_clickAndTradeDetails")
+
+CREATE INDEX "ix_TradeReport_fk_contractInfo_contract" ON "TradeReport" ("fk_contractInfo_contract")
+
+CREATE INDEX "ix_TradeReport_priceIntervalQuantityDetails_fk_priceInt_38b7" ON "TradeReport_priceIntervalQuantityDetails" ("fk_priceIntervalQuantityDetails")
+
+CREATE INDEX "ix_OrderReport_fk_contractInfo_contract" ON "OrderReport" ("fk_contractInfo_contract")
+
+CREATE INDEX "ix_OrderReport_priceIntervalQuantityDetails_fk_priceInt_5eb5" ON "OrderReport_priceIntervalQuantityDetails" ("fk_priceIntervalQuantityDetails")
+
+CREATE INDEX "ix_OrderReport_legContractId_fk_legContractId" ON "OrderReport_legContractId" ("fk_legContractId")
+
+CREATE INDEX "ix_OrderReport_legContract_fk_legContract" ON "OrderReport_legContract" ("fk_legContract")
+
+CREATE INDEX "ix_REMITTable1_contract_fk_contract" ON "REMITTable1_contract" (fk_contract)
+
+CREATE INDEX "ix_REMITTable1_OrderReport_fk_OrderReport" ON "REMITTable1_OrderReport" ("fk_OrderReport")
+
+CREATE INDEX "ix_REMITTable1_TradeReport_fk_TradeReport" ON "REMITTable1_TradeReport" ("fk_TradeReport")
+

--- a/tests/sample_models/table1/table1_ddl_postgresql_version1.sql
+++ b/tests/sample_models/table1/table1_ddl_postgresql_version1.sql
@@ -1,0 +1,360 @@
+
+CREATE TABLE "contractTradingHours" (
+	"pk_contractTradingHours" SERIAL NOT NULL, 
+	"startTime" VARCHAR(18), 
+	"endTime" VARCHAR(18), 
+	date VARCHAR(16), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_contractTradingHours" PRIMARY KEY ("pk_contractTradingHours"), 
+	CONSTRAINT "contractTradingHours_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "deliveryProfile" (
+	"pk_deliveryProfile" SERIAL NOT NULL, 
+	"loadDeliveryStartDate" VARCHAR(16), 
+	"loadDeliveryEndDate" VARCHAR(16), 
+	"daysOfTheWeek" VARCHAR(8000), 
+	"loadDeliveryStartTime" VARCHAR(8000), 
+	"loadDeliveryEndTime" VARCHAR(8000), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_deliveryProfile" PRIMARY KEY ("pk_deliveryProfile"), 
+	CONSTRAINT "deliveryProfile_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "fixingIndex" (
+	"pk_fixingIndex" SERIAL NOT NULL, 
+	"indexName" VARCHAR(150), 
+	"indexValue" FLOAT, 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_fixingIndex" PRIMARY KEY ("pk_fixingIndex"), 
+	CONSTRAINT "fixingIndex_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "optionDetails" (
+	"pk_optionDetails" SERIAL NOT NULL, 
+	"optionStyle" VARCHAR(1), 
+	"optionType" VARCHAR(1), 
+	"optionExerciseDate" VARCHAR(8000), 
+	"optionStrikePrice_value" FLOAT, 
+	"optionStrikePrice_currency" VARCHAR(3), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_optionDetails" PRIMARY KEY ("pk_optionDetails"), 
+	CONSTRAINT "optionDetails_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "priceIntervalQuantityDetails" (
+	"pk_priceIntervalQuantityDetails" SERIAL NOT NULL, 
+	"intervalStartDate" VARCHAR(16), 
+	"intervalEndDate" VARCHAR(16), 
+	"daysOfTheWeek" VARCHAR(1000), 
+	"intervalStartTime" VARCHAR(8000), 
+	"intervalEndTime" VARCHAR(8000), 
+	quantity FLOAT, 
+	unit VARCHAR(8), 
+	"priceTimeIntervalQuantity_value" FLOAT, 
+	"priceTimeIntervalQuantity_currency" VARCHAR(3), 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_priceIntervalQuantityDetails" PRIMARY KEY ("pk_priceIntervalQuantityDetails"), 
+	CONSTRAINT "priceIntervalQuantityDetails_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "clickAndTradeDetails" (
+	"pk_clickAndTradeDetails" SERIAL NOT NULL, 
+	"orderType" VARCHAR(3), 
+	"orderCondition" VARCHAR(8000), 
+	"orderStatus" VARCHAR(8000), 
+	"minimumExecuteVolume_value" FLOAT, 
+	"minimumExecuteVolume_unit" VARCHAR(8), 
+	"triggerDetails_priceLimit_value" FLOAT, 
+	"triggerDetails_priceLimit_currency" VARCHAR(3), 
+	"triggerDetails_triggerContractId" VARCHAR(50), 
+	"undisclosedVolume_value" FLOAT, 
+	"undisclosedVolume_unit" VARCHAR(8), 
+	"orderDuration_duration" VARCHAR(3), 
+	"orderDuration_expirationDateTime" TIMESTAMP WITH TIME ZONE, 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_clickAndTradeDetails" PRIMARY KEY ("pk_clickAndTradeDetails"), 
+	CONSTRAINT "clickAndTradeDetails_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE contract (
+	pk_contract SERIAL NOT NULL, 
+	"contractId" VARCHAR(50), 
+	"contractName" VARCHAR(200), 
+	"contractType" VARCHAR(5), 
+	"energyCommodity" VARCHAR(8000), 
+	"settlementMethod" VARCHAR(1), 
+	"organisedMarketPlaceIdentifier_type" VARCHAR(3), 
+	"organisedMarketPlaceIdentifier_value" VARCHAR(20), 
+	"lastTradingDateTime" TIMESTAMP WITH TIME ZONE, 
+	"fk_optionDetails" INTEGER, 
+	"deliveryPointOrZone" VARCHAR(8000), 
+	"deliveryStartDate" VARCHAR(16), 
+	"deliveryEndDate" VARCHAR(16), 
+	duration VARCHAR(1), 
+	"loadType" VARCHAR(2), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_contract PRIMARY KEY (pk_contract), 
+	CONSTRAINT contract_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY("fk_optionDetails") REFERENCES "optionDetails" ("pk_optionDetails")
+)
+
+
+CREATE TABLE "contract_fixingIndex" (
+	fk_contract INTEGER NOT NULL, 
+	"fk_fixingIndex" INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract), 
+	FOREIGN KEY("fk_fixingIndex") REFERENCES "fixingIndex" ("pk_fixingIndex")
+)
+
+
+CREATE TABLE "contract_contractTradingHours" (
+	fk_contract INTEGER NOT NULL, 
+	"fk_contractTradingHours" INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract), 
+	FOREIGN KEY("fk_contractTradingHours") REFERENCES "contractTradingHours" ("pk_contractTradingHours")
+)
+
+
+CREATE TABLE "contract_deliveryProfile" (
+	fk_contract INTEGER NOT NULL, 
+	"fk_deliveryProfile" INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract), 
+	FOREIGN KEY("fk_deliveryProfile") REFERENCES "deliveryProfile" ("pk_deliveryProfile")
+)
+
+
+CREATE TABLE "REMITTable1" (
+	"pk_REMITTable1" SERIAL NOT NULL, 
+	"reportingEntityID_type" VARCHAR(3), 
+	"reportingEntityID_value" VARCHAR(20), 
+	xml2db_input_file_path VARCHAR(256) NOT NULL, 
+	xml2db_processed_at TIMESTAMP WITH TIME ZONE, 
+	record_hash BYTEA, 
+	CONSTRAINT "cx_pk_REMITTable1" PRIMARY KEY ("pk_REMITTable1"), 
+	CONSTRAINT "REMITTable1_xml2db_record_hash" UNIQUE (record_hash)
+)
+
+
+CREATE TABLE "REMITTable1_contract" (
+	"fk_REMITTable1" INTEGER NOT NULL, 
+	fk_contract INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY("fk_REMITTable1") REFERENCES "REMITTable1" ("pk_REMITTable1"), 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE "OrderReport" (
+	"pk_OrderReport" SERIAL NOT NULL, 
+	"temp_pk_OrderReport" INTEGER, 
+	"fk_parent_REMITTable1" INTEGER, 
+	xml2db_row_number INTEGER NOT NULL, 
+	"RecordSeqNumber" INTEGER, 
+	"idOfMarketParticipant_type" VARCHAR(3), 
+	"idOfMarketParticipant_value" VARCHAR(20), 
+	"traderID_traderIdForOrganisedMarket" VARCHAR(100), 
+	"traderID_traderIdForMarketParticipant" VARCHAR(100), 
+	"beneficiaryIdentification_type" VARCHAR(3), 
+	"beneficiaryIdentification_value" VARCHAR(20), 
+	"tradingCapacity" VARCHAR(1), 
+	"buySellIndicator" VARCHAR(1), 
+	"orderId_uniqueOrderIdentifier" VARCHAR(100), 
+	"orderId_previousOrderIdentifier" VARCHAR(100), 
+	"orderType" VARCHAR(3), 
+	"orderCondition" VARCHAR(8000), 
+	"orderStatus" VARCHAR(8000), 
+	"minimumExecuteVolume_value" FLOAT, 
+	"minimumExecuteVolume_unit" VARCHAR(8), 
+	"triggerDetails_priceLimit_value" FLOAT, 
+	"triggerDetails_priceLimit_currency" VARCHAR(3), 
+	"triggerDetails_triggerContractId" VARCHAR(50), 
+	"undisclosedVolume_value" FLOAT, 
+	"undisclosedVolume_unit" VARCHAR(8), 
+	"orderDuration_duration" VARCHAR(3), 
+	"orderDuration_expirationDateTime" TIMESTAMP WITH TIME ZONE, 
+	"contractInfo_contractId" VARCHAR(50), 
+	"fk_contractInfo_contract" INTEGER, 
+	"organisedMarketPlaceIdentifier_type" VARCHAR(3), 
+	"organisedMarketPlaceIdentifier_value" VARCHAR(20), 
+	"transactionTime" TIMESTAMP WITH TIME ZONE, 
+	"originalEntryTime" TIMESTAMP WITH TIME ZONE, 
+	"linkedOrderId" VARCHAR(8000), 
+	"priceDetails_price" FLOAT, 
+	"priceDetails_priceCurrency" VARCHAR(3), 
+	"notionalAmountDetails_notionalAmount" FLOAT, 
+	"notionalAmountDetails_notionalCurrency" VARCHAR(3), 
+	quantity_value FLOAT, 
+	quantity_unit VARCHAR(8), 
+	"totalNotionalContractQuantity_value" FLOAT, 
+	"totalNotionalContractQuantity_unit" VARCHAR(6), 
+	"actionType" VARCHAR(1), 
+	"Extra" VARCHAR(1000), 
+	CONSTRAINT "cx_pk_OrderReport" PRIMARY KEY ("pk_OrderReport"), 
+	FOREIGN KEY("fk_parent_REMITTable1") REFERENCES "REMITTable1" ("pk_REMITTable1"), 
+	FOREIGN KEY("fk_contractInfo_contract") REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE "OrderReport_priceIntervalQuantityDetails" (
+	"fk_OrderReport" INTEGER NOT NULL, 
+	"fk_priceIntervalQuantityDetails" INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY("fk_OrderReport") REFERENCES "OrderReport" ("pk_OrderReport"), 
+	FOREIGN KEY("fk_priceIntervalQuantityDetails") REFERENCES "priceIntervalQuantityDetails" ("pk_priceIntervalQuantityDetails")
+)
+
+
+CREATE TABLE "TradeReport" (
+	"pk_TradeReport" SERIAL NOT NULL, 
+	"temp_pk_TradeReport" INTEGER, 
+	"fk_parent_REMITTable1" INTEGER, 
+	xml2db_row_number INTEGER NOT NULL, 
+	"RecordSeqNumber" INTEGER, 
+	"idOfMarketParticipant_type" VARCHAR(3), 
+	"idOfMarketParticipant_value" VARCHAR(20), 
+	"traderID_traderIdForOrganisedMarket" VARCHAR(100), 
+	"traderID_traderIdForMarketParticipant" VARCHAR(100), 
+	"otherMarketParticipant_type" VARCHAR(3), 
+	"otherMarketParticipant_value" VARCHAR(20), 
+	"beneficiaryIdentification_type" VARCHAR(3), 
+	"beneficiaryIdentification_value" VARCHAR(20), 
+	"tradingCapacity" VARCHAR(1), 
+	"buySellIndicator" VARCHAR(1), 
+	aggressor VARCHAR(1), 
+	"fk_clickAndTradeDetails" INTEGER, 
+	"contractInfo_contractId" VARCHAR(50), 
+	"fk_contractInfo_contract" INTEGER, 
+	"organisedMarketPlaceIdentifier_type" VARCHAR(3), 
+	"organisedMarketPlaceIdentifier_value" VARCHAR(20), 
+	"transactionTime" TIMESTAMP WITH TIME ZONE, 
+	"executionTime" TIMESTAMP WITH TIME ZONE, 
+	"uniqueTransactionIdentifier_uniqueTransactionIdentifier" VARCHAR(100), 
+	"uniqueTransactionIdentifier_additionalUtiInfo" VARCHAR(100), 
+	"linkedTransactionId" VARCHAR(8000), 
+	"linkedOrderId" VARCHAR(8000), 
+	"voiceBrokered" VARCHAR(1000), 
+	"priceDetails_price" FLOAT, 
+	"priceDetails_priceCurrency" VARCHAR(3), 
+	"notionalAmountDetails_notionalAmount" FLOAT, 
+	"notionalAmountDetails_notionalCurrency" VARCHAR(3), 
+	quantity_value FLOAT, 
+	quantity_unit VARCHAR(8), 
+	"totalNotionalContractQuantity_value" FLOAT, 
+	"totalNotionalContractQuantity_unit" VARCHAR(6), 
+	"terminationDate" TIMESTAMP WITH TIME ZONE, 
+	"actionType" VARCHAR(1), 
+	"Extra" VARCHAR(1000), 
+	CONSTRAINT "cx_pk_TradeReport" PRIMARY KEY ("pk_TradeReport"), 
+	FOREIGN KEY("fk_parent_REMITTable1") REFERENCES "REMITTable1" ("pk_REMITTable1"), 
+	FOREIGN KEY("fk_clickAndTradeDetails") REFERENCES "clickAndTradeDetails" ("pk_clickAndTradeDetails"), 
+	FOREIGN KEY("fk_contractInfo_contract") REFERENCES contract (pk_contract)
+)
+
+
+CREATE TABLE "TradeReport_priceIntervalQuantityDetails" (
+	"fk_TradeReport" INTEGER NOT NULL, 
+	"fk_priceIntervalQuantityDetails" INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY("fk_TradeReport") REFERENCES "TradeReport" ("pk_TradeReport"), 
+	FOREIGN KEY("fk_priceIntervalQuantityDetails") REFERENCES "priceIntervalQuantityDetails" ("pk_priceIntervalQuantityDetails")
+)
+
+
+CREATE TABLE "legContractId" (
+	"pk_legContractId" SERIAL NOT NULL, 
+	"fk_parent_OrderReport" INTEGER, 
+	xml2db_row_number INTEGER NOT NULL, 
+	"contractId" VARCHAR(50), 
+	"buySellIndicator" VARCHAR(1), 
+	CONSTRAINT "cx_pk_legContractId" PRIMARY KEY ("pk_legContractId"), 
+	FOREIGN KEY("fk_parent_OrderReport") REFERENCES "OrderReport" ("pk_OrderReport")
+)
+
+
+CREATE TABLE "legContract" (
+	"pk_legContract" SERIAL NOT NULL, 
+	"fk_parent_OrderReport" INTEGER, 
+	xml2db_row_number INTEGER NOT NULL, 
+	fk_contract INTEGER, 
+	"buySellIndicator" VARCHAR(1), 
+	CONSTRAINT "cx_pk_legContract" PRIMARY KEY ("pk_legContract"), 
+	FOREIGN KEY("fk_parent_OrderReport") REFERENCES "OrderReport" ("pk_OrderReport"), 
+	FOREIGN KEY(fk_contract) REFERENCES contract (pk_contract)
+)
+
+CREATE INDEX "idx_contractTradingHours_columnstore" ON "contractTradingHours" ()
+
+CREATE INDEX "idx_deliveryProfile_columnstore" ON "deliveryProfile" ()
+
+CREATE INDEX "idx_fixingIndex_columnstore" ON "fixingIndex" ()
+
+CREATE INDEX "idx_optionDetails_columnstore" ON "optionDetails" ()
+
+CREATE INDEX "idx_priceIntervalQuantityDetails_columnstore" ON "priceIntervalQuantityDetails" ()
+
+CREATE INDEX "idx_clickAndTradeDetails_columnstore" ON "clickAndTradeDetails" ()
+
+CREATE INDEX idx_contract_columnstore ON contract ()
+
+CREATE INDEX "ix_contract_fk_optionDetails" ON contract ("fk_optionDetails")
+
+CREATE INDEX "idx_contract_fixingIndex_columnstore" ON "contract_fixingIndex" ()
+
+CREATE INDEX "ix_contract_fixingIndex_fk_fixingIndex" ON "contract_fixingIndex" ("fk_fixingIndex")
+
+CREATE INDEX "idx_contract_contractTradingHours_columnstore" ON "contract_contractTradingHours" ()
+
+CREATE INDEX "ix_contract_contractTradingHours_fk_contractTradingHours" ON "contract_contractTradingHours" ("fk_contractTradingHours")
+
+CREATE INDEX "idx_contract_deliveryProfile_columnstore" ON "contract_deliveryProfile" ()
+
+CREATE INDEX "ix_contract_deliveryProfile_fk_deliveryProfile" ON "contract_deliveryProfile" ("fk_deliveryProfile")
+
+CREATE INDEX "idx_REMITTable1_columnstore" ON "REMITTable1" ()
+
+CREATE INDEX "idx_REMITTable1_contract_columnstore" ON "REMITTable1_contract" ()
+
+CREATE INDEX "ix_REMITTable1_contract_fk_contract" ON "REMITTable1_contract" (fk_contract)
+
+CREATE INDEX "idx_OrderReport_columnstore" ON "OrderReport" ()
+
+CREATE INDEX "ix_OrderReport_fk_contractInfo_contract" ON "OrderReport" ("fk_contractInfo_contract")
+
+CREATE INDEX "ix_OrderReport_fk_parent_REMITTable1" ON "OrderReport" ("fk_parent_REMITTable1")
+
+CREATE INDEX "idx_OrderReport_priceIntervalQuantityDetails_columnstore" ON "OrderReport_priceIntervalQuantityDetails" ()
+
+CREATE INDEX "ix_OrderReport_priceIntervalQuantityDetails_fk_priceInt_5eb5" ON "OrderReport_priceIntervalQuantityDetails" ("fk_priceIntervalQuantityDetails")
+
+CREATE INDEX "idx_TradeReport_columnstore" ON "TradeReport" ()
+
+CREATE INDEX "ix_TradeReport_fk_clickAndTradeDetails" ON "TradeReport" ("fk_clickAndTradeDetails")
+
+CREATE INDEX "ix_TradeReport_fk_contractInfo_contract" ON "TradeReport" ("fk_contractInfo_contract")
+
+CREATE INDEX "ix_TradeReport_fk_parent_REMITTable1" ON "TradeReport" ("fk_parent_REMITTable1")
+
+CREATE INDEX "idx_TradeReport_priceIntervalQuantityDetails_columnstore" ON "TradeReport_priceIntervalQuantityDetails" ()
+
+CREATE INDEX "ix_TradeReport_priceIntervalQuantityDetails_fk_priceInt_38b7" ON "TradeReport_priceIntervalQuantityDetails" ("fk_priceIntervalQuantityDetails")
+
+CREATE INDEX "idx_legContractId_columnstore" ON "legContractId" ()
+
+CREATE INDEX "ix_legContractId_fk_parent_OrderReport" ON "legContractId" ("fk_parent_OrderReport")
+
+CREATE INDEX "idx_legContract_columnstore" ON "legContract" ()
+
+CREATE INDEX "ix_legContract_fk_contract" ON "legContract" (fk_contract)
+
+CREATE INDEX "ix_legContract_fk_parent_OrderReport" ON "legContract" ("fk_parent_OrderReport")
+

--- a/tests/sample_models/table1/table1_erd_version0.md
+++ b/tests/sample_models/table1/table1_erd_version0.md
@@ -1,0 +1,168 @@
+```mermaid
+erDiagram
+    REMITTable1 ||--o{ contract : "contractList_contract*"
+    REMITTable1 ||--o{ OrderReport : "OrderList_OrderReport*"
+    REMITTable1 ||--o{ TradeReport : "TradeList_TradeReport*"
+    REMITTable1 {
+        string reportingEntityID_type
+        string reportingEntityID_value
+    }
+    OrderReport ||--|| contract : "contractInfo_contract"
+    OrderReport ||--o{ priceIntervalQuantityDetails : "priceIntervalQuantityDetails*"
+    OrderReport ||--o{ legContractId : "contractInfo_legContractId*"
+    OrderReport ||--o{ legContract : "contractInfo_legContract*"
+    OrderReport {
+        integer RecordSeqNumber
+        string idOfMarketParticipant_type
+        string idOfMarketParticipant_value
+        string traderID_traderIdForOrganisedMarket
+        string traderID_traderIdForMarketParticipant
+        string beneficiaryIdentification_type
+        string beneficiaryIdentification_value
+        string tradingCapacity
+        string buySellIndicator
+        string orderId_uniqueOrderIdentifier
+        string orderId_previousOrderIdentifier
+        string orderType
+        string-N orderCondition
+        string-N orderStatus
+        decimal minimumExecuteVolume_value
+        string minimumExecuteVolume_unit
+        decimal triggerDetails_priceLimit_value
+        string triggerDetails_priceLimit_currency
+        string triggerDetails_triggerContractId
+        decimal undisclosedVolume_value
+        string undisclosedVolume_unit
+        string orderDuration_duration
+        dateTime orderDuration_expirationDateTime
+        string contractInfo_contractId
+        string organisedMarketPlaceIdentifier_type
+        string organisedMarketPlaceIdentifier_value
+        dateTime transactionTime
+        dateTime originalEntryTime
+        string-N linkedOrderId
+        decimal priceDetails_price
+        string priceDetails_priceCurrency
+        decimal notionalAmountDetails_notionalAmount
+        string notionalAmountDetails_notionalCurrency
+        decimal quantity_value
+        string quantity_unit
+        decimal totalNotionalContractQuantity_value
+        string totalNotionalContractQuantity_unit
+        string actionType
+        string Extra
+    }
+    TradeReport ||--o| clickAndTradeDetails : "clickAndTradeDetails"
+    TradeReport ||--|| contract : "contractInfo_contract"
+    TradeReport ||--o{ priceIntervalQuantityDetails : "priceIntervalQuantityDetails*"
+    TradeReport {
+        integer RecordSeqNumber
+        string idOfMarketParticipant_type
+        string idOfMarketParticipant_value
+        string traderID_traderIdForOrganisedMarket
+        string traderID_traderIdForMarketParticipant
+        string otherMarketParticipant_type
+        string otherMarketParticipant_value
+        string beneficiaryIdentification_type
+        string beneficiaryIdentification_value
+        string tradingCapacity
+        string buySellIndicator
+        string aggressor
+        string contractInfo_contractId
+        string organisedMarketPlaceIdentifier_type
+        string organisedMarketPlaceIdentifier_value
+        dateTime transactionTime
+        dateTime executionTime
+        string uniqueTransactionIdentifier_uniqueTransactionIdentifier
+        string uniqueTransactionIdentifier_additionalUtiInfo
+        string-N linkedTransactionId
+        string-N linkedOrderId
+        string voiceBrokered
+        decimal priceDetails_price
+        string priceDetails_priceCurrency
+        decimal notionalAmountDetails_notionalAmount
+        string notionalAmountDetails_notionalCurrency
+        decimal quantity_value
+        string quantity_unit
+        decimal totalNotionalContractQuantity_value
+        string totalNotionalContractQuantity_unit
+        dateTime terminationDate
+        string actionType
+        string Extra
+    }
+    legContract ||--|| contract : "contract"
+    legContract {
+        string buySellIndicator
+    }
+    contract ||--o| optionDetails : "optionDetails"
+    contract ||--o{ fixingIndex : "fixingIndex*"
+    contract ||--o{ contractTradingHours : "contractTradingHours*"
+    contract ||--|{ deliveryProfile : "deliveryProfile*"
+    contract {
+        string contractId
+        string contractName
+        string contractType
+        string energyCommodity
+        string settlementMethod
+        string organisedMarketPlaceIdentifier_type
+        string organisedMarketPlaceIdentifier_value
+        dateTime lastTradingDateTime
+        string-N deliveryPointOrZone
+        date deliveryStartDate
+        date deliveryEndDate
+        string duration
+        string loadType
+    }
+    clickAndTradeDetails {
+        string orderType
+        string-N orderCondition
+        string-N orderStatus
+        decimal minimumExecuteVolume_value
+        string minimumExecuteVolume_unit
+        decimal triggerDetails_priceLimit_value
+        string triggerDetails_priceLimit_currency
+        string triggerDetails_triggerContractId
+        decimal undisclosedVolume_value
+        string undisclosedVolume_unit
+        string orderDuration_duration
+        dateTime orderDuration_expirationDateTime
+    }
+    priceIntervalQuantityDetails {
+        date intervalStartDate
+        date intervalEndDate
+        string daysOfTheWeek
+        time-N intervalStartTime
+        time-N intervalEndTime
+        decimal quantity
+        string unit
+        decimal priceTimeIntervalQuantity_value
+        string priceTimeIntervalQuantity_currency
+    }
+    legContractId {
+        string contractId
+        string buySellIndicator
+    }
+    optionDetails {
+        string optionStyle
+        string optionType
+        date-N optionExerciseDate
+        decimal optionStrikePrice_value
+        string optionStrikePrice_currency
+    }
+    fixingIndex {
+        string indexName
+        decimal indexValue
+    }
+    deliveryProfile {
+        date loadDeliveryStartDate
+        date loadDeliveryEndDate
+        string-N daysOfTheWeek
+        time-N loadDeliveryStartTime
+        time-N loadDeliveryEndTime
+    }
+    contractTradingHours {
+        time startTime
+        time endTime
+        date date
+    }
+```

--- a/tests/sample_models/table1/table1_erd_version1.md
+++ b/tests/sample_models/table1/table1_erd_version1.md
@@ -1,0 +1,168 @@
+```mermaid
+erDiagram
+    legContract ||--|| contract : "contract"
+    legContract {
+        string buySellIndicator
+    }
+    legContractId {
+        string contractId
+        string buySellIndicator
+    }
+    TradeReport ||--o| clickAndTradeDetails : "clickAndTradeDetails"
+    TradeReport ||--|| contract : "contractInfo_contract"
+    TradeReport ||--o{ priceIntervalQuantityDetails : "priceIntervalQuantityDetails*"
+    TradeReport {
+        integer RecordSeqNumber
+        string idOfMarketParticipant_type
+        string idOfMarketParticipant_value
+        string traderID_traderIdForOrganisedMarket
+        string traderID_traderIdForMarketParticipant
+        string otherMarketParticipant_type
+        string otherMarketParticipant_value
+        string beneficiaryIdentification_type
+        string beneficiaryIdentification_value
+        string tradingCapacity
+        string buySellIndicator
+        string aggressor
+        string contractInfo_contractId
+        string organisedMarketPlaceIdentifier_type
+        string organisedMarketPlaceIdentifier_value
+        dateTime transactionTime
+        dateTime executionTime
+        string uniqueTransactionIdentifier_uniqueTransactionIdentifier
+        string uniqueTransactionIdentifier_additionalUtiInfo
+        string-N linkedTransactionId
+        string-N linkedOrderId
+        string voiceBrokered
+        decimal priceDetails_price
+        string priceDetails_priceCurrency
+        decimal notionalAmountDetails_notionalAmount
+        string notionalAmountDetails_notionalCurrency
+        decimal quantity_value
+        string quantity_unit
+        decimal totalNotionalContractQuantity_value
+        string totalNotionalContractQuantity_unit
+        dateTime terminationDate
+        string actionType
+        string Extra
+    }
+    OrderReport ||--|| contract : "contractInfo_contract"
+    OrderReport ||--o{ priceIntervalQuantityDetails : "priceIntervalQuantityDetails*"
+    OrderReport ||--o{ legContractId : "contractInfo_legContractId"
+    OrderReport ||--o{ legContract : "contractInfo_legContract"
+    OrderReport {
+        integer RecordSeqNumber
+        string idOfMarketParticipant_type
+        string idOfMarketParticipant_value
+        string traderID_traderIdForOrganisedMarket
+        string traderID_traderIdForMarketParticipant
+        string beneficiaryIdentification_type
+        string beneficiaryIdentification_value
+        string tradingCapacity
+        string buySellIndicator
+        string orderId_uniqueOrderIdentifier
+        string orderId_previousOrderIdentifier
+        string orderType
+        string-N orderCondition
+        string-N orderStatus
+        decimal minimumExecuteVolume_value
+        string minimumExecuteVolume_unit
+        decimal triggerDetails_priceLimit_value
+        string triggerDetails_priceLimit_currency
+        string triggerDetails_triggerContractId
+        decimal undisclosedVolume_value
+        string undisclosedVolume_unit
+        string orderDuration_duration
+        dateTime orderDuration_expirationDateTime
+        string contractInfo_contractId
+        string organisedMarketPlaceIdentifier_type
+        string organisedMarketPlaceIdentifier_value
+        dateTime transactionTime
+        dateTime originalEntryTime
+        string-N linkedOrderId
+        decimal priceDetails_price
+        string priceDetails_priceCurrency
+        decimal notionalAmountDetails_notionalAmount
+        string notionalAmountDetails_notionalCurrency
+        decimal quantity_value
+        string quantity_unit
+        decimal totalNotionalContractQuantity_value
+        string totalNotionalContractQuantity_unit
+        string actionType
+        string Extra
+    }
+    REMITTable1 ||--o{ contract : "contractList_contract*"
+    REMITTable1 ||--o{ OrderReport : "OrderList_OrderReport"
+    REMITTable1 ||--o{ TradeReport : "TradeList_TradeReport"
+    REMITTable1 {
+        string reportingEntityID_type
+        string reportingEntityID_value
+    }
+    contract ||--o| optionDetails : "optionDetails"
+    contract ||--o{ fixingIndex : "fixingIndex*"
+    contract ||--o{ contractTradingHours : "contractTradingHours*"
+    contract ||--|{ deliveryProfile : "deliveryProfile*"
+    contract {
+        string contractId
+        string contractName
+        string contractType
+        string energyCommodity
+        string settlementMethod
+        string organisedMarketPlaceIdentifier_type
+        string organisedMarketPlaceIdentifier_value
+        dateTime lastTradingDateTime
+        string-N deliveryPointOrZone
+        date deliveryStartDate
+        date deliveryEndDate
+        string duration
+        string loadType
+    }
+    clickAndTradeDetails {
+        string orderType
+        string-N orderCondition
+        string-N orderStatus
+        decimal minimumExecuteVolume_value
+        string minimumExecuteVolume_unit
+        decimal triggerDetails_priceLimit_value
+        string triggerDetails_priceLimit_currency
+        string triggerDetails_triggerContractId
+        decimal undisclosedVolume_value
+        string undisclosedVolume_unit
+        string orderDuration_duration
+        dateTime orderDuration_expirationDateTime
+    }
+    priceIntervalQuantityDetails {
+        date intervalStartDate
+        date intervalEndDate
+        string daysOfTheWeek
+        time-N intervalStartTime
+        time-N intervalEndTime
+        decimal quantity
+        string unit
+        decimal priceTimeIntervalQuantity_value
+        string priceTimeIntervalQuantity_currency
+    }
+    optionDetails {
+        string optionStyle
+        string optionType
+        date-N optionExerciseDate
+        decimal optionStrikePrice_value
+        string optionStrikePrice_currency
+    }
+    fixingIndex {
+        string indexName
+        decimal indexValue
+    }
+    deliveryProfile {
+        date loadDeliveryStartDate
+        date loadDeliveryEndDate
+        string-N daysOfTheWeek
+        time-N loadDeliveryStartTime
+        time-N loadDeliveryEndTime
+    }
+    contractTradingHours {
+        time startTime
+        time endTime
+        date date
+    }
+```

--- a/tests/test_models_output.py
+++ b/tests/test_models_output.py
@@ -1,0 +1,76 @@
+import os
+import pytest
+from sqlalchemy.dialects import postgresql, mssql
+
+from xml2db import DataModel
+
+from .sample_models import models
+
+
+@pytest.mark.parametrize(
+    "test_config",
+    [
+        {**model, **model["versions"][i], "version_id": i}
+        for model in models
+        for i in range(len(model["versions"]))
+    ],
+)
+def test_model_erd(test_config):
+    """A test to check if generated ERD matches saved output"""
+
+    model = DataModel(
+        test_config["xsd_path"],
+        short_name=test_config["id"],
+        model_config=test_config["config"],
+    )
+
+    expected = open(
+        os.path.join(
+            os.path.dirname(test_config["xsd_path"]),
+            f"{test_config['id']}_erd_version{test_config['version_id']}.md",
+        ),
+        "r",
+    ).read()
+
+    actual = "```mermaid\n" + model.get_entity_rel_diagram(text_context=False) + "\n```"
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "test_config",
+    [
+        {**model, **model["versions"][i], "version_id": i, "dialect": d.dialect()}
+        for model in models
+        for i in range(len(model["versions"]))
+        for d in [postgresql, mssql]
+    ],
+)
+def test_model_ddl(test_config):
+    """A test to check if generated SQL DDL matches saved output"""
+
+    model = DataModel(
+        test_config["xsd_path"],
+        short_name=test_config["id"],
+        model_config=test_config["config"],
+    )
+
+    expected = open(
+        os.path.join(
+            os.path.dirname(test_config["xsd_path"]),
+            f"{test_config['id']}_ddl_{test_config['dialect'].name}_version{test_config['version_id']}.sql",
+        ),
+        "r",
+    ).read()
+
+    actual = "".join(
+        [
+            str(s.compile(dialect=test_config["dialect"]))
+            for s in model.get_all_create_table_statements()
+        ]
+        + [
+            str(s.compile(dialect=test_config["dialect"])) + "\n\n"
+            for s in model.get_all_create_index_statements()
+        ]
+    )
+
+    assert actual == expected


### PR DESCRIPTION
This PR adds generated ERD representation and SQL DDL for test models. The current outputs are committed to the repo, and a new test checks whether these outputs change. The goal is to prevent non intentional changes in target model structure.