### PR TITLE
Fixes on model relations

### DIFF
--- a/src/xml2db/model.py
+++ b/src/xml2db/model.py
@@ -359,6 +359,8 @@ class DataModel:
             parent_occurs = [1, 1]
             if particle.parent and hasattr(particle.parent, "model"):
                 parent_occurs = get_occurs(particle.parent)
+                if particle.parent.model == "choice":
+                    parent_occurs[0] = 0
             return [
                 min(parent_occurs[0], particle.min_occurs),
                 (

--- a/src/xml2db/table/relations.py
+++ b/src/xml2db/table/relations.py
@@ -94,7 +94,7 @@ class DataModelRelationN(DataModelRelation):
         self.rel_table_name = (
             f"{self.table.name}_{self.name}_{self.other_table.name}"
             if not self.name.endswith(self.other_table.name)
-            else f"{self.table.name}_{self.other_table.name}"
+            else f"{self.table.name}_{self.name}"
         )
         prefix = f"temp_{self.table.temp_prefix}_"
         if self.other_table.is_reused:

--- a/src/xml2db/table/transformed_table.py
+++ b/src/xml2db/table/transformed_table.py
@@ -137,7 +137,7 @@ class DataModelTableTransformed(DataModelTable):
             else:
                 raise DataModelConfigError(
                     f"Transform value '{field_config['transform']}' cannot be applied"
-                    f" to field {field_name} of table '{self.name}'."
+                    f" to field '{field_name}' of table '{self.name}'."
                 )
         else:
             if field_type == "col":
@@ -148,13 +148,11 @@ class DataModelTableTransformed(DataModelTable):
                     self.relations_1[field_name].occurs[0] == 1
                     or len(self.relations_1[field_name].other_table.columns) <= 4
                 ) and len(self.relations_1[field_name].other_table.parents_n) == 0:
-                    transform = (
+                    return (
                         "elevate_wo_prefix"
                         if len(self.columns) == 0 and len(self.relations_1) == 1
                         else "elevate"
                     )
-                    if self._can_transform_field("rel1", field_name, transform):
-                        return transform
 
     def _elevate_relation_1(
         self, rel_name, transform

--- a/tests/sample_models/junit10/junit10_ddl_mssql_version0.sql
+++ b/tests/sample_models/junit10/junit10_ddl_mssql_version0.sql
@@ -222,7 +222,7 @@ CREATE TABLE junit10 (
 )
 
 
-CREATE TABLE junit10_testsuite (
+CREATE TABLE junit10_testsuites_testsuite (
 	fk_junit10 INTEGER NOT NULL, 
 	fk_testsuite INTEGER NOT NULL, 
 	FOREIGN KEY(fk_junit10) REFERENCES junit10 (pk_junit10), 
@@ -271,5 +271,5 @@ CREATE INDEX [ix_junit10_rerunError_fk_flakyError] ON junit10 ([rerunError_fk_fl
 
 CREATE INDEX [ix_junit10_rerunFailure_fk_flakyError] ON junit10 ([rerunFailure_fk_flakyError])
 
-CREATE INDEX ix_junit10_testsuite_fk_testsuite ON junit10_testsuite (fk_testsuite)
+CREATE INDEX ix_junit10_testsuites_testsuite_fk_testsuite ON junit10_testsuites_testsuite (fk_testsuite)
 

--- a/tests/sample_models/junit10/junit10_ddl_mysql_version0.sql
+++ b/tests/sample_models/junit10/junit10_ddl_mysql_version0.sql
@@ -222,7 +222,7 @@ CREATE TABLE junit10 (
 )
 
 
-CREATE TABLE junit10_testsuite (
+CREATE TABLE junit10_testsuites_testsuite (
 	fk_junit10 INTEGER NOT NULL, 
 	fk_testsuite INTEGER NOT NULL, 
 	FOREIGN KEY(fk_junit10) REFERENCES junit10 (pk_junit10), 
@@ -271,5 +271,5 @@ CREATE INDEX `ix_junit10_rerunError_fk_flakyError` ON junit10 (`rerunError_fk_fl
 
 CREATE INDEX `ix_junit10_rerunFailure_fk_flakyError` ON junit10 (`rerunFailure_fk_flakyError`)
 
-CREATE INDEX ix_junit10_testsuite_fk_testsuite ON junit10_testsuite (fk_testsuite)
+CREATE INDEX ix_junit10_testsuites_testsuite_fk_testsuite ON junit10_testsuites_testsuite (fk_testsuite)
 

--- a/tests/sample_models/junit10/junit10_ddl_postgresql_version0.sql
+++ b/tests/sample_models/junit10/junit10_ddl_postgresql_version0.sql
@@ -222,7 +222,7 @@ CREATE TABLE junit10 (
 )
 
 
-CREATE TABLE junit10_testsuite (
+CREATE TABLE junit10_testsuites_testsuite (
 	fk_junit10 INTEGER NOT NULL, 
 	fk_testsuite INTEGER NOT NULL, 
 	FOREIGN KEY(fk_junit10) REFERENCES junit10 (pk_junit10), 
@@ -271,5 +271,5 @@ CREATE INDEX "ix_junit10_rerunError_fk_flakyError" ON junit10 ("rerunError_fk_fl
 
 CREATE INDEX "ix_junit10_rerunFailure_fk_flakyError" ON junit10 ("rerunFailure_fk_flakyError")
 
-CREATE INDEX ix_junit10_testsuite_fk_testsuite ON junit10_testsuite (fk_testsuite)
+CREATE INDEX ix_junit10_testsuites_testsuite_fk_testsuite ON junit10_testsuites_testsuite (fk_testsuite)
 

--- a/tests/sample_models/models.py
+++ b/tests/sample_models/models.py
@@ -49,6 +49,9 @@ models = [
                     "row_numbers": True,
                     "as_columnstore": True,
                     "tables": {
+                        "REMITTable1": {
+                            "fields": {"contractList": {"transform": "elevate_wo_prefix"}}
+                        },
                         "TradeReport": {"reuse": False},
                         "OrderReport": {"reuse": False},
                         "legContract": {"reuse": False},

--- a/tests/sample_models/table1/table1_ddl_mssql_version0.sql
+++ b/tests/sample_models/table1/table1_ddl_mssql_version0.sql
@@ -261,7 +261,7 @@ CREATE TABLE [OrderReport_priceIntervalQuantityDetails] (
 )
 
 
-CREATE TABLE [OrderReport_legContractId] (
+CREATE TABLE [OrderReport_contractInfo_legContractId] (
 	[fk_OrderReport] INTEGER NOT NULL, 
 	[fk_legContractId] INTEGER NOT NULL, 
 	FOREIGN KEY([fk_OrderReport]) REFERENCES [OrderReport] ([pk_OrderReport]), 
@@ -269,7 +269,7 @@ CREATE TABLE [OrderReport_legContractId] (
 )
 
 
-CREATE TABLE [OrderReport_legContract] (
+CREATE TABLE [OrderReport_contractInfo_legContract] (
 	[fk_OrderReport] INTEGER NOT NULL, 
 	[fk_legContract] INTEGER NOT NULL, 
 	FOREIGN KEY([fk_OrderReport]) REFERENCES [OrderReport] ([pk_OrderReport]), 
@@ -289,7 +289,7 @@ CREATE TABLE [REMITTable1] (
 )
 
 
-CREATE TABLE [REMITTable1_contract] (
+CREATE TABLE [REMITTable1_contractList_contract] (
 	[fk_REMITTable1] INTEGER NOT NULL, 
 	fk_contract INTEGER NOT NULL, 
 	FOREIGN KEY([fk_REMITTable1]) REFERENCES [REMITTable1] ([pk_REMITTable1]), 
@@ -297,7 +297,7 @@ CREATE TABLE [REMITTable1_contract] (
 )
 
 
-CREATE TABLE [REMITTable1_OrderReport] (
+CREATE TABLE [REMITTable1_OrderList_OrderReport] (
 	[fk_REMITTable1] INTEGER NOT NULL, 
 	[fk_OrderReport] INTEGER NOT NULL, 
 	FOREIGN KEY([fk_REMITTable1]) REFERENCES [REMITTable1] ([pk_REMITTable1]), 
@@ -305,7 +305,7 @@ CREATE TABLE [REMITTable1_OrderReport] (
 )
 
 
-CREATE TABLE [REMITTable1_TradeReport] (
+CREATE TABLE [REMITTable1_TradeList_TradeReport] (
 	[fk_REMITTable1] INTEGER NOT NULL, 
 	[fk_TradeReport] INTEGER NOT NULL, 
 	FOREIGN KEY([fk_REMITTable1]) REFERENCES [REMITTable1] ([pk_REMITTable1]), 
@@ -332,13 +332,13 @@ CREATE INDEX [ix_OrderReport_fk_contractInfo_contract] ON [OrderReport] ([fk_con
 
 CREATE INDEX [ix_OrderReport_priceIntervalQuantityDetails_fk_priceIntervalQuantityDetails] ON [OrderReport_priceIntervalQuantityDetails] ([fk_priceIntervalQuantityDetails])
 
-CREATE INDEX [ix_OrderReport_legContractId_fk_legContractId] ON [OrderReport_legContractId] ([fk_legContractId])
+CREATE INDEX [ix_OrderReport_contractInfo_legContractId_fk_legContractId] ON [OrderReport_contractInfo_legContractId] ([fk_legContractId])
 
-CREATE INDEX [ix_OrderReport_legContract_fk_legContract] ON [OrderReport_legContract] ([fk_legContract])
+CREATE INDEX [ix_OrderReport_contractInfo_legContract_fk_legContract] ON [OrderReport_contractInfo_legContract] ([fk_legContract])
 
-CREATE INDEX [ix_REMITTable1_contract_fk_contract] ON [REMITTable1_contract] (fk_contract)
+CREATE INDEX [ix_REMITTable1_contractList_contract_fk_contract] ON [REMITTable1_contractList_contract] (fk_contract)
 
-CREATE INDEX [ix_REMITTable1_OrderReport_fk_OrderReport] ON [REMITTable1_OrderReport] ([fk_OrderReport])
+CREATE INDEX [ix_REMITTable1_OrderList_OrderReport_fk_OrderReport] ON [REMITTable1_OrderList_OrderReport] ([fk_OrderReport])
 
-CREATE INDEX [ix_REMITTable1_TradeReport_fk_TradeReport] ON [REMITTable1_TradeReport] ([fk_TradeReport])
+CREATE INDEX [ix_REMITTable1_TradeList_TradeReport_fk_TradeReport] ON [REMITTable1_TradeList_TradeReport] ([fk_TradeReport])
 

--- a/tests/sample_models/table1/table1_ddl_mysql_version0.sql
+++ b/tests/sample_models/table1/table1_ddl_mysql_version0.sql
@@ -261,7 +261,7 @@ CREATE TABLE `OrderReport_priceIntervalQuantityDetails` (
 )
 
 
-CREATE TABLE `OrderReport_legContractId` (
+CREATE TABLE `OrderReport_contractInfo_legContractId` (
 	`fk_OrderReport` INTEGER NOT NULL, 
 	`fk_legContractId` INTEGER NOT NULL, 
 	FOREIGN KEY(`fk_OrderReport`) REFERENCES `OrderReport` (`pk_OrderReport`), 
@@ -269,7 +269,7 @@ CREATE TABLE `OrderReport_legContractId` (
 )
 
 
-CREATE TABLE `OrderReport_legContract` (
+CREATE TABLE `OrderReport_contractInfo_legContract` (
 	`fk_OrderReport` INTEGER NOT NULL, 
 	`fk_legContract` INTEGER NOT NULL, 
 	FOREIGN KEY(`fk_OrderReport`) REFERENCES `OrderReport` (`pk_OrderReport`), 
@@ -289,7 +289,7 @@ CREATE TABLE `REMITTable1` (
 )
 
 
-CREATE TABLE `REMITTable1_contract` (
+CREATE TABLE `REMITTable1_contractList_contract` (
 	`fk_REMITTable1` INTEGER NOT NULL, 
 	fk_contract INTEGER NOT NULL, 
 	FOREIGN KEY(`fk_REMITTable1`) REFERENCES `REMITTable1` (`pk_REMITTable1`), 
@@ -297,7 +297,7 @@ CREATE TABLE `REMITTable1_contract` (
 )
 
 
-CREATE TABLE `REMITTable1_OrderReport` (
+CREATE TABLE `REMITTable1_OrderList_OrderReport` (
 	`fk_REMITTable1` INTEGER NOT NULL, 
 	`fk_OrderReport` INTEGER NOT NULL, 
 	FOREIGN KEY(`fk_REMITTable1`) REFERENCES `REMITTable1` (`pk_REMITTable1`), 
@@ -305,7 +305,7 @@ CREATE TABLE `REMITTable1_OrderReport` (
 )
 
 
-CREATE TABLE `REMITTable1_TradeReport` (
+CREATE TABLE `REMITTable1_TradeList_TradeReport` (
 	`fk_REMITTable1` INTEGER NOT NULL, 
 	`fk_TradeReport` INTEGER NOT NULL, 
 	FOREIGN KEY(`fk_REMITTable1`) REFERENCES `REMITTable1` (`pk_REMITTable1`), 
@@ -332,13 +332,13 @@ CREATE INDEX `ix_OrderReport_fk_contractInfo_contract` ON `OrderReport` (`fk_con
 
 CREATE INDEX `ix_OrderReport_priceIntervalQuantityDetails_fk_priceInte_5eb5` ON `OrderReport_priceIntervalQuantityDetails` (`fk_priceIntervalQuantityDetails`)
 
-CREATE INDEX `ix_OrderReport_legContractId_fk_legContractId` ON `OrderReport_legContractId` (`fk_legContractId`)
+CREATE INDEX `ix_OrderReport_contractInfo_legContractId_fk_legContractId` ON `OrderReport_contractInfo_legContractId` (`fk_legContractId`)
 
-CREATE INDEX `ix_OrderReport_legContract_fk_legContract` ON `OrderReport_legContract` (`fk_legContract`)
+CREATE INDEX `ix_OrderReport_contractInfo_legContract_fk_legContract` ON `OrderReport_contractInfo_legContract` (`fk_legContract`)
 
-CREATE INDEX `ix_REMITTable1_contract_fk_contract` ON `REMITTable1_contract` (fk_contract)
+CREATE INDEX `ix_REMITTable1_contractList_contract_fk_contract` ON `REMITTable1_contractList_contract` (fk_contract)
 
-CREATE INDEX `ix_REMITTable1_OrderReport_fk_OrderReport` ON `REMITTable1_OrderReport` (`fk_OrderReport`)
+CREATE INDEX `ix_REMITTable1_OrderList_OrderReport_fk_OrderReport` ON `REMITTable1_OrderList_OrderReport` (`fk_OrderReport`)
 
-CREATE INDEX `ix_REMITTable1_TradeReport_fk_TradeReport` ON `REMITTable1_TradeReport` (`fk_TradeReport`)
+CREATE INDEX `ix_REMITTable1_TradeList_TradeReport_fk_TradeReport` ON `REMITTable1_TradeList_TradeReport` (`fk_TradeReport`)
 

--- a/tests/sample_models/table1/table1_ddl_postgresql_version0.sql
+++ b/tests/sample_models/table1/table1_ddl_postgresql_version0.sql
@@ -261,7 +261,7 @@ CREATE TABLE "OrderReport_priceIntervalQuantityDetails" (
 )
 
 
-CREATE TABLE "OrderReport_legContractId" (
+CREATE TABLE "OrderReport_contractInfo_legContractId" (
 	"fk_OrderReport" INTEGER NOT NULL, 
 	"fk_legContractId" INTEGER NOT NULL, 
 	FOREIGN KEY("fk_OrderReport") REFERENCES "OrderReport" ("pk_OrderReport"), 
@@ -269,7 +269,7 @@ CREATE TABLE "OrderReport_legContractId" (
 )
 
 
-CREATE TABLE "OrderReport_legContract" (
+CREATE TABLE "OrderReport_contractInfo_legContract" (
 	"fk_OrderReport" INTEGER NOT NULL, 
 	"fk_legContract" INTEGER NOT NULL, 
 	FOREIGN KEY("fk_OrderReport") REFERENCES "OrderReport" ("pk_OrderReport"), 
@@ -289,7 +289,7 @@ CREATE TABLE "REMITTable1" (
 )
 
 
-CREATE TABLE "REMITTable1_contract" (
+CREATE TABLE "REMITTable1_contractList_contract" (
 	"fk_REMITTable1" INTEGER NOT NULL, 
 	fk_contract INTEGER NOT NULL, 
 	FOREIGN KEY("fk_REMITTable1") REFERENCES "REMITTable1" ("pk_REMITTable1"), 
@@ -297,7 +297,7 @@ CREATE TABLE "REMITTable1_contract" (
 )
 
 
-CREATE TABLE "REMITTable1_OrderReport" (
+CREATE TABLE "REMITTable1_OrderList_OrderReport" (
 	"fk_REMITTable1" INTEGER NOT NULL, 
 	"fk_OrderReport" INTEGER NOT NULL, 
 	FOREIGN KEY("fk_REMITTable1") REFERENCES "REMITTable1" ("pk_REMITTable1"), 
@@ -305,7 +305,7 @@ CREATE TABLE "REMITTable1_OrderReport" (
 )
 
 
-CREATE TABLE "REMITTable1_TradeReport" (
+CREATE TABLE "REMITTable1_TradeList_TradeReport" (
 	"fk_REMITTable1" INTEGER NOT NULL, 
 	"fk_TradeReport" INTEGER NOT NULL, 
 	FOREIGN KEY("fk_REMITTable1") REFERENCES "REMITTable1" ("pk_REMITTable1"), 
@@ -332,13 +332,13 @@ CREATE INDEX "ix_OrderReport_fk_contractInfo_contract" ON "OrderReport" ("fk_con
 
 CREATE INDEX "ix_OrderReport_priceIntervalQuantityDetails_fk_priceInt_5eb5" ON "OrderReport_priceIntervalQuantityDetails" ("fk_priceIntervalQuantityDetails")
 
-CREATE INDEX "ix_OrderReport_legContractId_fk_legContractId" ON "OrderReport_legContractId" ("fk_legContractId")
+CREATE INDEX "ix_OrderReport_contractInfo_legContractId_fk_legContractId" ON "OrderReport_contractInfo_legContractId" ("fk_legContractId")
 
-CREATE INDEX "ix_OrderReport_legContract_fk_legContract" ON "OrderReport_legContract" ("fk_legContract")
+CREATE INDEX "ix_OrderReport_contractInfo_legContract_fk_legContract" ON "OrderReport_contractInfo_legContract" ("fk_legContract")
 
-CREATE INDEX "ix_REMITTable1_contract_fk_contract" ON "REMITTable1_contract" (fk_contract)
+CREATE INDEX "ix_REMITTable1_contractList_contract_fk_contract" ON "REMITTable1_contractList_contract" (fk_contract)
 
-CREATE INDEX "ix_REMITTable1_OrderReport_fk_OrderReport" ON "REMITTable1_OrderReport" ("fk_OrderReport")
+CREATE INDEX "ix_REMITTable1_OrderList_OrderReport_fk_OrderReport" ON "REMITTable1_OrderList_OrderReport" ("fk_OrderReport")
 
-CREATE INDEX "ix_REMITTable1_TradeReport_fk_TradeReport" ON "REMITTable1_TradeReport" ("fk_TradeReport")
+CREATE INDEX "ix_REMITTable1_TradeList_TradeReport_fk_TradeReport" ON "REMITTable1_TradeList_TradeReport" ("fk_TradeReport")
 

--- a/tests/sample_models/table1/table1_erd_version0.md
+++ b/tests/sample_models/table1/table1_erd_version0.md
@@ -7,7 +7,7 @@ erDiagram
         string reportingEntityID_type
         string reportingEntityID_value
     }
-    OrderReport ||--|| contract : "contractInfo_contract"
+    OrderReport ||--o| contract : "contractInfo_contract"
     OrderReport ||--o{ priceIntervalQuantityDetails : "priceIntervalQuantityDetails*"
     OrderReport ||--o{ legContractId : "contractInfo_legContractId*"
     OrderReport ||--o{ legContract : "contractInfo_legContract*"
@@ -53,7 +53,7 @@ erDiagram
         string Extra
     }
     TradeReport ||--o| clickAndTradeDetails : "clickAndTradeDetails"
-    TradeReport ||--|| contract : "contractInfo_contract"
+    TradeReport ||--o| contract : "contractInfo_contract"
     TradeReport ||--o{ priceIntervalQuantityDetails : "priceIntervalQuantityDetails*"
     TradeReport {
         integer RecordSeqNumber

--- a/tests/sample_models/table1/table1_erd_version1.md
+++ b/tests/sample_models/table1/table1_erd_version1.md
@@ -9,7 +9,7 @@ erDiagram
         string buySellIndicator
     }
     TradeReport ||--o| clickAndTradeDetails : "clickAndTradeDetails"
-    TradeReport ||--|| contract : "contractInfo_contract"
+    TradeReport ||--o| contract : "contractInfo_contract"
     TradeReport ||--o{ priceIntervalQuantityDetails : "priceIntervalQuantityDetails*"
     TradeReport {
         integer RecordSeqNumber
@@ -46,7 +46,7 @@ erDiagram
         string actionType
         string Extra
     }
-    OrderReport ||--|| contract : "contractInfo_contract"
+    OrderReport ||--o| contract : "contractInfo_contract"
     OrderReport ||--o{ priceIntervalQuantityDetails : "priceIntervalQuantityDetails*"
     OrderReport ||--o{ legContractId : "contractInfo_legContractId"
     OrderReport ||--o{ legContract : "contractInfo_legContract"
@@ -91,7 +91,7 @@ erDiagram
         string actionType
         string Extra
     }
-    REMITTable1 ||--o{ contract : "contractList_contract*"
+    REMITTable1 ||--o{ contract : "contract*"
     REMITTable1 ||--o{ OrderReport : "OrderList_OrderReport"
     REMITTable1 ||--o{ TradeReport : "TradeList_TradeReport"
     REMITTable1 {


### PR DESCRIPTION
This PR fix some bugs on data model creation:
* set minOccurs to 0 for complex types within choice model group
* actually use the relation name for the relation table name
* update test models output to reflect those changes