### PR TITLE
Enable loading several documents at the same time

### DIFF
--- a/.github/workflows/integration-tests-mssql.yml
+++ b/.github/workflows/integration-tests-mssql.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
           
       - name: Install dependencies
         run: |

--- a/.github/workflows/integration-tests-mysql.yml
+++ b/.github/workflows/integration-tests-mysql.yml
@@ -32,10 +32,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
         
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
           
       - name: Install dependencies
         run: |

--- a/.github/workflows/integration-tests-postgres.yml
+++ b/.github/workflows/integration-tests-postgres.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
-    container: python:3.11-bookworm
+    container: python:3.12-bookworm
     services:
       postgres:
         image: postgres
@@ -29,10 +29,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
           
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3.12
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install pypa/build
       run: >-
         python3 -m

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -64,7 +64,7 @@ clustered columnstore indexes. The default value is `False` (disabled).
 useful for instance to add the name of the file which has been parsed, or a timestamp, etc. Columns should be specified
 as dicts, the only required keys are `name` and `type` (a SQLAlchemy type object); other keys will be passed directly
 as keyword arguments to `sqlalchemy.Column`. Actual values need to be passed to 
-[`Document.insert_into_target_tables`](api/document.md#xml2db.document.Document.insert_into_target_tables) for each 
+[`DataModel.parse_xml`](api/data_model.md#xml2db.model.DataModel.parse_xml) for each 
 parsed documents, as a `dict`, using the `metadata` argument.
 * `record_hash_column_name`: the column name to use to store records hash data (defaults to `xml2db_record_hash`).
 * `record_hash_constructor`: a function used to build a hash, with a signature similar to `hashlib` constructor 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -121,6 +121,25 @@ troubleshooting if need be.
     [`metadata_columns` option](configuring.md#model-configuration) and create additional columns in the root table.
     It can be used for instance to save file name or loading timestamp.
 
+    Actual values need to be passed to [`DataModel.parse_xml`](api/data_model.md#xml2db.model.DataModel.parse_xml) for 
+    each parsed documents, as a `dict`, using the `metadata` argument.
+
+!!! note
+    You can also load multiple documents at the same time to the database, which could make the process faster if you 
+    have a lot of small XML files to load:
+    ``` py
+    data = None
+    for xml_file in files:
+        document = data_model.parse_xml(
+            xml_file="path/to/file.xml",
+            flat_data=data,
+        )
+        data = document.data
+    document.insert_into_target_tables()
+    ```
+
+
+
 ## Getting back the data into XML
 
 You can extract the data from the database into XML files. This was implemented primarily to be able to test the package

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -7,3 +7,7 @@
   --md-accent-fg-color--light:  #2a8cd0;
   --md-accent-fg-color--dark:   #116baa;
 }
+
+.md-typeset .admonition, .md-typeset details {
+  font-size: .75rem;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xml2db"
-version = "0.11.0"
+version = "0.12.0"
 authors = [
   { name="Commission de régulation de l'énergie", email="opensource@cre.fr" },
 ]

--- a/src/xml2db/model.py
+++ b/src/xml2db/model.py
@@ -676,9 +676,11 @@ class DataModel:
     def parse_xml(
         self,
         xml_file: Union[str, BytesIO],
+        metadata: dict = None,
         skip_validation: bool = True,
         iterparse: bool = True,
         recover: bool = False,
+        flat_data: dict = None,
     ) -> Document:
         """Parse an XML document based on this data model
 
@@ -686,9 +688,13 @@ class DataModel:
 
         Args:
             xml_file: The path or the file object of an XML file to parse
+            metadata: A dict of metadata values to add to the root table (a value for each key defined in
+                `metadata_columns` passed to model config)
             skip_validation: Should we validate the documents against the schema first?
             iterparse: Parse XML using iterative parsing, which is a bit slower but uses less memory
             recover: Should we try to parse incorrect XML? (argument passed to lxml parser)
+            flat_data: A dict containing flat data if we want to add data to another dataset instead of creating
+                a new one
 
         Returns:
             A parsed [`Document`](document.md) object
@@ -696,9 +702,11 @@ class DataModel:
         doc = Document(self)
         doc.parse_xml(
             xml_file=xml_file,
+            metadata=metadata,
             skip_validation=skip_validation,
             iterparse=iterparse,
             recover=recover,
+            flat_data=flat_data,
         )
         return doc
 

--- a/tests/sample_models/models.py
+++ b/tests/sample_models/models.py
@@ -6,9 +6,9 @@ import hashlib
 def make_sample_index(table_name):
     def wrapped():
         yield sqlalchemy.Index(
-            f"{table_name}_fk_parent_REMITTable1_idx",
-            "fk_parent_REMITTable1"
+            f"{table_name}_fk_parent_REMITTable1_idx", "fk_parent_REMITTable1"
         )
+
     return wrapped
 
 
@@ -219,4 +219,3 @@ def _generate_models_output():
 
 if __name__ == "__main__":
     _generate_models_output()
-


### PR DESCRIPTION
To load a lot of small documents faster, we can parse several documents to a same `Document` instance and load them all at once into the database.

This requires moving the `metadata` argument from `Document.insert_into_target_tables` to `DataModel.parse_xml`, as this method can be used to load different documents.