### PR TITLE
Improve support for some XSD features

### DIFF
--- a/.github/workflows/integration-tests-mssql.yml
+++ b/.github/workflows/integration-tests-mssql.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       mssql:
         image: mcr.microsoft.com/mssql/server:2019-latest

--- a/.github/workflows/integration-tests-mysql.yml
+++ b/.github/workflows/integration-tests-mysql.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       mysql:
         image: mysql:8.0

--- a/.github/workflows/integration-tests-postgres.yml
+++ b/.github/workflows/integration-tests-postgres.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: python:3.12-bookworm
     services:
       postgres:

--- a/docs/how_it_works.md
+++ b/docs/how_it_works.md
@@ -123,8 +123,10 @@ original one.
 
 ### Recursive XSD
 
-Recursive XML schemas are not supported, because most of the time they will result in cycles in foreign key constraints
-dependencies, which we cannot handle easily.
+Recursive XML schemas are not fully supported, because they result in cycles in tables dependencies, which would make
+the process much more complex. Whenever a field which would introduce a dependency cycle is detected in the XSD, it is 
+discarded with a warning, which means that the corresponding data in XML files will not be imported. The rest of the
+data should be processed correctly.
 
 ### Mixed content elements
 

--- a/src/xml2db/document.py
+++ b/src/xml2db/document.py
@@ -174,11 +174,7 @@ class Document:
             for field_type, key, field in model_table.fields:
                 if field_type == "col":
                     content_key = (
-                        (
-                            f"{key[:-5]}__attr"
-                            if key.endswith("_attr")
-                            else f"{key}__attr"
-                        )
+                        (f"{key[:-5]}__attr" if field.has_suffix else f"{key}__attr")
                         if field.is_attr
                         else key
                     )
@@ -334,7 +330,7 @@ class Document:
                     content_key = (
                         (
                             f"{rel_name[:-5]}__attr"
-                            if rel_name.endswith("_attr")
+                            if rel.has_suffix
                             else f"{rel_name}__attr"
                         )
                         if rel.is_attr

--- a/src/xml2db/model.py
+++ b/src/xml2db/model.py
@@ -434,17 +434,20 @@ class DataModel:
                 max_length,
                 allow_empty,
             ) = recurse_parse_simple_type([attrib.type])
+            suffix = attrib_name in children_names
             parent_table.add_column(
-                f"{attrib_name}{'_attr' if attrib_name in children_names else ''}",
+                f"{attrib_name}{'_attr' if suffix else ''}",
                 data_type,
                 [0, 1],
                 min_length,
                 max_length,
                 True,
+                suffix,
                 False,
                 allow_empty,
                 None,
             )
+
         nested_containers = []
         # go through the children to add either arguments either relations to the current element
         for child in parent_node:
@@ -470,6 +473,7 @@ class DataModel:
                                 if child.parent
                                 and child.parent.max_occurs != 1
                                 and child.parent.model != "choice"
+                                and child.max_occurs == 1
                                 else None
                             ),
                         )
@@ -496,6 +500,7 @@ class DataModel:
                         occurs,
                         min_length,
                         max_length,
+                        False,
                         False,
                         False,
                         allow_empty,
@@ -555,6 +560,7 @@ class DataModel:
                 [0, 1],
                 min_length,
                 max_length,
+                False,
                 False,
                 True,
                 allow_empty,

--- a/src/xml2db/table/column.py
+++ b/src/xml2db/table/column.py
@@ -167,6 +167,7 @@ class DataModelColumn:
         min_length: int,
         max_length: Union[int, None],
         is_attr: bool,
+        has_suffix: bool,
         is_content: bool,
         allow_empty: bool,
         ngroup: Union[int, None],
@@ -181,6 +182,7 @@ class DataModelColumn:
         self.min_length = min_length
         self.max_length = max_length
         self.is_attr = is_attr
+        self.has_suffix = has_suffix
         self.is_content = is_content
         self.allow_empty = allow_empty
         self.ngroup = ngroup

--- a/src/xml2db/table/column.py
+++ b/src/xml2db/table/column.py
@@ -36,7 +36,7 @@ def types_mapping_default(temp: bool, col: "DataModelColumn") -> Any:
         return Double
     if col.data_type == "dateTime":
         return DateTime(timezone=True)
-    if col.data_type == "integer" or col.data_type == "int":
+    if col.data_type in ["integer", "int", "positiveInteger", "nonNegativeInteger"]:
         return Integer
     if col.data_type == "boolean":
         return Boolean
@@ -83,7 +83,7 @@ def types_mapping_mssql(temp: bool, col: "DataModelColumn") -> Any:
         # using the DATETIMEOFFSET directly in the temporary table caused issues when inserting data in the target
         # table with INSERT INTO SELECT converts datetime VARCHAR to DATETIMEOFFSET without errors
         return mssql.VARCHAR(100) if temp else mssql.DATETIMEOFFSET
-    if col.data_type == "integer" or col.data_type == "int":
+    if col.data_type in ["integer", "int", "positiveInteger", "nonNegativeInteger"]:
         return Integer
     if col.data_type == "boolean":
         return Boolean

--- a/src/xml2db/table/column.py
+++ b/src/xml2db/table/column.py
@@ -36,11 +36,18 @@ def types_mapping_default(temp: bool, col: "DataModelColumn") -> Any:
         return Double
     if col.data_type == "dateTime":
         return DateTime(timezone=True)
-    if col.data_type in ["integer", "int", "positiveInteger", "nonNegativeInteger"]:
+    if col.data_type in [
+        "integer",
+        "int",
+        "nonPositiveInteger",
+        "nonNegativeInteger",
+        "positiveInteger",
+        "negativeInteger",
+    ]:
         return Integer
     if col.data_type == "boolean":
         return Boolean
-    if col.data_type == "byte":
+    if col.data_type in ["short", "byte"]:
         return SmallInteger
     if col.data_type == "long":
         return BigInteger
@@ -77,20 +84,10 @@ def types_mapping_mssql(temp: bool, col: "DataModelColumn") -> Any:
     """
     if col.occurs[1] != 1:
         return mssql.VARCHAR(8000)
-    if col.data_type in ["decimal", "float", "double"]:
-        return Double
     if col.data_type == "dateTime":
         # using the DATETIMEOFFSET directly in the temporary table caused issues when inserting data in the target
         # table with INSERT INTO SELECT converts datetime VARCHAR to DATETIMEOFFSET without errors
         return mssql.VARCHAR(100) if temp else mssql.DATETIMEOFFSET
-    if col.data_type in ["integer", "int", "positiveInteger", "nonNegativeInteger"]:
-        return Integer
-    if col.data_type == "boolean":
-        return Boolean
-    if col.data_type == "byte":
-        return SmallInteger
-    if col.data_type == "long":
-        return BigInteger
     if col.data_type == "date":
         return mssql.VARCHAR(16)
     if col.data_type == "time":
@@ -106,12 +103,7 @@ def types_mapping_mssql(temp: bool, col: "DataModelColumn") -> Any:
         if col.max_length == col.min_length:
             return mssql.BINARY(col.max_length)
         return mssql.VARBINARY(col.max_length)
-    else:
-        logger.warning(
-            f"unknown type '{col.data_type}' for column '{col.name}', defaulting to VARCHAR(1000) "
-            f"(this can be overridden by providing a field type in the configuration)"
-        )
-        return mssql.VARCHAR(1000)
+    return types_mapping_default(temp, col)
 
 
 def types_mapping_mysql(temp: bool, col: "DataModelColumn") -> Any:

--- a/src/xml2db/table/reused_table.py
+++ b/src/xml2db/table/reused_table.py
@@ -71,6 +71,7 @@ class DataModelTableReused(DataModelTableTransformed):
                 False,
                 False,
                 False,
+                False,
                 None,
                 self.config,
                 self.data_model,

--- a/src/xml2db/table/table.py
+++ b/src/xml2db/table/table.py
@@ -130,6 +130,7 @@ class DataModelTable:
         min_length: int,
         max_length: Union[int, None],
         is_attr: bool,
+        has_suffix: bool,
         is_content: bool,
         allow_empty: bool,
         ngroup: Union[str, None],
@@ -143,6 +144,7 @@ class DataModelTable:
             min_length: minimum length
             max_length: maximum length
             is_attr: is XML attribute or element?
+            has_suffix: for an attribute, do we need the '_attr' suffix?
             is_content: is content of a mixed type element?
             allow_empty: is nullable?
             ngroup: a string id signaling that the column belongs to a nested sequence
@@ -155,6 +157,7 @@ class DataModelTable:
             min_length,
             max_length,
             is_attr,
+            has_suffix,
             is_content,
             allow_empty,
             ngroup,

--- a/src/xml2db/table/transformed_table.py
+++ b/src/xml2db/table/transformed_table.py
@@ -76,6 +76,7 @@ class DataModelTableTransformed(DataModelTable):
                 False,
                 False,
                 False,
+                False,
                 None,
                 self.config,
                 self.data_model,
@@ -87,6 +88,7 @@ class DataModelTableTransformed(DataModelTable):
                 [1, 1],
                 min(min_lengths) if all(e is not None for e in min_lengths) else None,
                 max(max_lengths) if all(e is not None for e in max_lengths) else None,
+                False,
                 False,
                 False,
                 any(allow_empty),
@@ -193,6 +195,7 @@ class DataModelTableTransformed(DataModelTable):
                     child_field.min_length,
                     child_field.max_length,
                     child_field.is_attr,
+                    child_field.has_suffix,
                     child_field.is_content,
                     child_field.allow_empty,
                     child_field.ngroup,
@@ -276,9 +279,12 @@ class DataModelTableTransformed(DataModelTable):
 
         # if the table can be transformed, stop here
         if self._is_table_choice_transform_applicable():
+            fields_transform = {}
+            for col in self.columns.values():
+                fields_transform[(self.type_name, col.name)] = (None, "join")
             self._transform_to_choice()
             self.is_simplified = True
-            return {self.type_name: "choice"}, {}
+            return {self.type_name: "choice"}, fields_transform
 
         # loop through field to transform them if need be
         out_fields = []

--- a/src/xml2db/xml_converter.py
+++ b/src/xml2db/xml_converter.py
@@ -128,7 +128,7 @@ class XMLConverter:
                 key
                 != "{http://www.w3.org/2001/XMLSchema-instance}noNamespaceSchemaLocation"
             ):
-                content[f"{key}__attr"] = [val]
+                content[f"{key}__attr"] = [val.strip() if val.strip() else val]
 
         if node.text and node.text.strip():
             content["value"] = [node.text.strip()]
@@ -138,11 +138,14 @@ class XMLConverter:
                 key = element.tag.split("}")[1] if "}" in element.tag else element.tag
                 node_type_key = (node_type, key)
                 value = None
-                if element.text and element.text.strip():
-                    value = element.text
-                transform = self.model.fields_transforms.get(
-                    node_type_key, (None, "join")
-                )[1]
+                if element.text:
+                    value = (
+                        element.text.strip() if element.text.strip() else element.text
+                    )
+                if node_type_key not in self.model.fields_transforms:
+                    # skip the node if it is not in the data model
+                    continue
+                transform = self.model.fields_transforms[node_type_key][1]
                 if transform != "join":
                     value = self._parse_xml_node(
                         self.model.fields_transforms[node_type_key][0],
@@ -150,10 +153,11 @@ class XMLConverter:
                         transform not in ["elevate", "elevate_wo_prefix"],
                         hash_maps,
                     )
-                if key in content:
-                    content[key].append(value)
-                else:
-                    content[key] = [value]
+                if value is not None:
+                    if key in content:
+                        content[key].append(value)
+                    else:
+                        content[key] = [value]
 
         node = self._transform_node(node_type, content)
 
@@ -190,6 +194,7 @@ class XMLConverter:
         hash_maps = {}
 
         joined_values = False
+        skipped_nodes = 0
         for event, element in etree.iterparse(
             xml_file,
             recover=recover,
@@ -197,12 +202,17 @@ class XMLConverter:
             remove_blank_text=True,
         ):
             key = element.tag.split("}")[1] if "}" in element.tag else element.tag
-            if event == "start":
+
+            if event == "start" and skipped_nodes > 0:
+                skipped_nodes += 1
+
+            elif event == "start":
                 if nodes_stack[-1][0]:
                     node_type_key = (nodes_stack[-1][0], key)
-                    node_type, transform = self.model.fields_transforms.get(
-                        node_type_key, (None, "join")
-                    )
+                    if node_type_key not in self.model.fields_transforms:
+                        skipped_nodes += 1
+                        continue
+                    node_type, transform = self.model.fields_transforms[node_type_key]
                 else:
                     node_type, transform = self.model.root_table, None
                 joined_values = transform == "join"
@@ -213,28 +223,41 @@ class XMLConverter:
                             attrib_key
                             != "{http://www.w3.org/2001/XMLSchema-instance}noNamespaceSchemaLocation"
                         ):
-                            content[f"{attrib_key}__attr"] = [attrib_val]
+                            content[f"{attrib_key}__attr"] = [
+                                attrib_val.strip() if attrib_val.strip() else attrib_val
+                            ]
                     nodes_stack.append((node_type, content))
 
+            elif event == "end" and skipped_nodes > 0:
+                skipped_nodes -= 1
+
             elif event == "end":
-                # joined_values was set with the previous "start" event just before
+                # joined_values was set with the previous "start" event just before and corresponds to lists of simple
+                # type elements
                 if joined_values:
+                    value = None
                     if element.text:
-                        if key in nodes_stack[-1][1]:
-                            nodes_stack[-1][1][key].append(element.text)
+                        if element.text.strip():
+                            value = element.text.strip()
                         else:
-                            nodes_stack[-1][1][key] = [element.text]
+                            value = element.text
+                    if key in nodes_stack[-1][1]:
+                        nodes_stack[-1][1][key].append(value)
+                    else:
+                        nodes_stack[-1][1][key] = [value]
+
+                # else, we have completed a complex type node
                 else:
                     node = nodes_stack.pop()
                     if nodes_stack[-1][0]:
                         node_type_key = (nodes_stack[-1][0], key)
-                        node_type, transform = self.model.fields_transforms.get(
-                            node_type_key, (None, "join")
-                        )
+                        node_type, transform = self.model.fields_transforms[
+                            node_type_key
+                        ]
                     else:
                         node_type, transform = self.model.root_table, None
-                    if element.text:
-                        node[1]["value"] = [element.text]
+                    if element.text and element.text.strip():
+                        node[1]["value"] = [element.text.strip()]
                     node = self._transform_node(*node)
                     if transform not in ["elevate", "elevate_wo_prefix"]:
                         node = self._compute_hash_deduplicate(node, hash_maps)
@@ -293,18 +316,26 @@ class XMLConverter:
             A tuple of (node_type, content, hash) representing a node after deduplication
         """
         node_type, content = node
+        if node_type not in self.model.tables:
+            return "", None, b""
         table = self.model.tables[node_type]
 
         h = self.model.model_config["record_hash_constructor"]()
         for field_type, name, field in table.fields:
             if field_type == "col":
                 if field.is_attr:
-                    if f"{name}__attr" in content:
-                        h.update(str(content[f"{name}__attr"]).encode("utf-8"))
-                    elif f"{name[:-5]}__attr" in content:
-                        h.update(str(content[f"{name[:-5]}__attr"]).encode("utf-8"))
-                    else:
-                        h.update(str(None).encode("utf-8"))
+                    h.update(
+                        str(
+                            content.get(
+                                (
+                                    f"{name[:-5]}__attr"
+                                    if field.has_suffix
+                                    else f"{name}__attr"
+                                ),
+                                None,
+                            )
+                        ).encode("utf-8")
+                    )
                 else:
                     h.update(str(content.get(name, None)).encode("utf-8"))
             elif field_type == "rel1":
@@ -429,13 +460,13 @@ class XMLConverter:
             text_content = None
             if field_type == "col":
                 if rel.is_attr:
-                    if f"{rel_name}__attr" in content:
-                        attributes[rel.name_chain[-1][0]] = content[
-                            f"{rel_name}__attr"
-                        ][0]
-                    elif f"{rel_name[:-5]}__attr" in content:
+                    if rel.has_suffix and f"{rel_name[:-5]}__attr" in content:
                         attributes[rel.name_chain[-1][0][:-5]] = content[
                             f"{rel_name[:-5]}__attr"
+                        ][0]
+                    elif not rel.has_suffix and f"{rel_name}__attr" in content:
+                        attributes[rel.name_chain[-1][0]] = content[
+                            f"{rel_name}__attr"
                         ][0]
                 elif rel_name in content:
                     if rel.is_content:
@@ -462,7 +493,8 @@ class XMLConverter:
             if prev_ngroup and rel.ngroup != prev_ngroup:
                 for ngroup_children in zip_longest(*ngroup_stack):
                     for child in ngroup_children:
-                        nodes_stack[-1][1].append(child)
+                        if child is not None:
+                            nodes_stack[-1][1].append(child)
                 ngroup_stack = []
             prev_ngroup = rel.ngroup
             if len(children) > 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,15 @@ import pytest
 
 from xml2db import DataModel
 
+models_path = "tests/sample_models"
+
+
+def list_xml_path(test_config, key):
+    path = os.path.join(models_path, test_config["id"], key)
+    if os.path.isdir(path):
+        return [os.path.join(path, f) for f in os.listdir(path)]
+    return []
+
 
 @pytest.fixture
 def conn_string():
@@ -14,7 +23,9 @@ def conn_string():
 def setup_db_model(conn_string, model_config):
     db_schema = f"test_xml2db"
     model = DataModel(
-        xsd_file=model_config.get("xsd_path"),
+        xsd_file=str(
+            os.path.join(models_path, model_config["id"], model_config["xsd"])
+        ),
         short_name=model_config.get("id"),
         connection_string=conn_string,
         db_schema=db_schema,

--- a/tests/sample_models/models.py
+++ b/tests/sample_models/models.py
@@ -18,8 +18,7 @@ models = [
         "id": "orders",
         "long_name": "A simple model for shipment orders",
         "description": "This model was made up to be a simple case which could represent real business cases.",
-        "xsd_path": "tests/sample_models/orders/orders.xsd",
-        "xml_path": "tests/sample_models/orders/xml",
+        "xsd": "orders.xsd",
         "versions": [
             {
                 "config": {
@@ -80,8 +79,7 @@ models = [
         "long_name": "Data model for reporting standard contracts in the European energy markets",
         "description": "This model is one of the official models published by the Agency for the cooperation of energy"
         "regulators to report energy markets transaction data.",
-        "xsd_path": "tests/sample_models/table1/Table1_V2.xsd",
-        "xml_path": "tests/sample_models/table1/xml",
+        "xsd": "Table1_V2.xsd",
         "versions": [
             {
                 "config": {
@@ -137,8 +135,7 @@ models = [
             "Xunit XSD was taken from https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd"
             " and amended to remove its recursive nature."
         ),
-        "xsd_path": "tests/sample_models/junit10/junit-10.xsd",
-        "xml_path": "tests/sample_models/junit10/xml",
+        "xsd": "junit-10.xsd",
         "versions": [
             {
                 "config": {
@@ -185,7 +182,7 @@ def _generate_models_output():
 
     for model_config in models:
         for i in range(len(model_config["versions"])):
-            xsd_path = os.path.join("../../", model_config["xsd_path"])
+            xsd_path = os.path.join(model_config["id"], model_config["xsd"])
             for dialect in [d.dialect() for d in [postgresql, mssql, mysql]]:
                 model = DataModel(
                     xsd_path,

--- a/tests/sample_models/orders/base_types.xsd
+++ b/tests/sample_models/orders/base_types.xsd
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:bt="http://www.cre.fr/xml2db/base_types.xsd"
            targetNamespace="http://www.cre.fr/xml2db/base_types.xsd"
            elementFormDefault="qualified">
     <xs:simpleType name="stringtype">
@@ -32,4 +33,10 @@
     <xs:simpleType name="dectype">
         <xs:restriction base="xs:decimal"/>
     </xs:simpleType>
+    <xs:simpleType name="CoordinatesType">
+        <xs:restriction base="xs:float" />
+    </xs:simpleType>
+   <xs:simpleType name="CoordinatesListType">
+      <xs:list itemType="bt:CoordinatesType"/>
+   </xs:simpleType>
 </xs:schema>

--- a/tests/sample_models/orders/equivalent_xml/order1.xml
+++ b/tests/sample_models/orders/equivalent_xml/order1.xml
@@ -8,8 +8,8 @@
       <city>string</city>
       <zip codingSystem="us">102832</zip>
       <country>FR</country>
-      <phoneNumber>+1732897354</phoneNumber>
-      <phoneNumber>+1732323984</phoneNumber>
+      <phoneNumber>    +1732897354</phoneNumber>
+      <phoneNumber>    +1732323984</phoneNumber>
       <companyId>
         <bic>JIDAZIO786DAZH</bic>
       </companyId>

--- a/tests/sample_models/orders/equivalent_xml/order1.xml
+++ b/tests/sample_models/orders/equivalent_xml/order1.xml
@@ -18,24 +18,6 @@
       <product>
         <name>product 1</name>
         <version>regular</version>
-        <features>
-          <intfeature>
-            <id>length</id>
-            <value>60</value>
-          </intfeature>
-          <intfeature>
-            <id>width</id>
-            <value>40</value>
-          </intfeature>
-          <intfeature>
-            <id>weight</id>
-            <value>10</value>
-          </intfeature>
-          <stringfeature>
-            <id>color</id>
-            <value>red</value>
-          </stringfeature>
-        </features>
       </product>
       <quantity>13</quantity>
       <price>340.23</price>

--- a/tests/sample_models/orders/equivalent_xml/order1a.xml
+++ b/tests/sample_models/orders/equivalent_xml/order1a.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <orders xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" batch_id="5" xsi:noNamespaceSchemaLocation="../orders.xsd">
   <version>2</version>
-  <shiporder orderid="1" processed_at="2023-09-10T09:37:00.000+02:00">
+  <shiporder orderid="1" processed_at="2023-09-10T09:37:00.000+02:00  ">
     <orderperson name="billing">
-      <name>Bob</name>
+      <name>    Bob    </name>
       <address>string</address>
       <city>string</city>
       <zip codingSystem="us">102832</zip>
@@ -16,29 +16,27 @@
     </orderperson>
     <item>
       <product>
-        <name>product 1</name>
+        <name>
+          product 1
+        </name>
         <version>regular</version>
-        <features>
-          <intfeature>
-            <id>length</id>
-            <value>60</value>
-          </intfeature>
-          <intfeature>
-            <id>width</id>
-            <value>40</value>
-          </intfeature>
-          <intfeature>
-            <id>weight</id>
-            <value>10</value>
-          </intfeature>
-          <stringfeature>
-            <id>color</id>
-            <value>red</value>
-          </stringfeature>
-        </features>
+        <related_product>
+          <name>
+            product 1
+          </name>
+          <version>premium</version>
+        </related_product>
+        <related_product>
+          <name>
+            product 1
+          </name>
+          <version>basic</version>
+        </related_product>
       </product>
       <quantity>13</quantity>
-      <price>340.23</price>
+      <price>
+        340.23
+      </price>
       <currency>EUR</currency>
     </item>
     <item>
@@ -56,7 +54,7 @@
         <name>product 1</name>
         <version>premium</version>
       </product>
-      <quantity>25</quantity>
+      <quantity>  25</quantity>
       <price>21.7</price>
       <currency>EUR</currency>
     </item>

--- a/tests/sample_models/orders/invalid_xml/invalid.xml
+++ b/tests/sample_models/orders/invalid_xml/invalid.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <orders xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" batch_id="4" xsi:noNamespaceSchemaLocation="../orders.xsd">
   <shiporder orderid="3" processed_at="2023-09-11T18:27:56.000+02:00">
-    <orderperson>
+    <orderperson name="billing">
       <name>Alice</name>
       <address>string</address>
       <city>string</city>
       <zip codingSystem="int">21093</zip>
       <country>US</country>
     </orderperson>
-    <shiptoContact>
+    <shiptoContact name="shipping">
       <name>Bob</name>
       <address>string</address>
       <city>string</city>

--- a/tests/sample_models/orders/invalid_xml/malformed_recover.xml
+++ b/tests/sample_models/orders/invalid_xml/malformed_recover.xml
@@ -2,7 +2,7 @@
 <orders xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" batch_id="5" xsi:noNamespaceSchemaLocation="../orders.xsd">
   <version>3</version>
   <shiporder orderid="1" processed_at="2023-09-10T09:37:00.000+02:00">
-    <orderperson>
+    <orderperson name="billing">
       <name>Bob</name>
       <address>string</address>
       <city>string</city>

--- a/tests/sample_models/orders/orders.xsd
+++ b/tests/sample_models/orders/orders.xsd
@@ -34,13 +34,16 @@
             <xs:element name="country" type="bt:stringtype"/>
             <xs:element name="phoneNumber" type="bt:stringtype" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="companyId" type="companyIdType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="coordinates" type="bt:CoordinatesListType" minOccurs="0" />
         </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
     </xs:complexType>
 
     <xs:complexType name="producttype">
         <xs:sequence>
             <xs:element name="name" type="bt:stringtype"/>
             <xs:element name="version" type="bt:stringtype"/>
+            <xs:element name="related_product" type="producttype" minOccurs="0" maxOccurs="unbounded" />
         </xs:sequence>
     </xs:complexType>
 

--- a/tests/sample_models/orders/orders.xsd
+++ b/tests/sample_models/orders/orders.xsd
@@ -34,16 +34,38 @@
             <xs:element name="country" type="bt:stringtype"/>
             <xs:element name="phoneNumber" type="bt:stringtype" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="companyId" type="companyIdType" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="coordinates" type="bt:CoordinatesListType" minOccurs="0" />
+            <xs:element name="coordinates" type="bt:CoordinatesListType" minOccurs="0"/>
         </xs:sequence>
-        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="intfeaturetype">
+        <xs:sequence>
+            <xs:element name="id" type="xs:string"/>
+            <xs:element name="value" type="bt:inttype"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="stringfeaturetype">
+        <xs:sequence>
+            <xs:element name="id" type="xs:string"/>
+            <xs:element name="value" type="bt:stringtype"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="productfeaturestype">
+        <xs:sequence maxOccurs="unbounded">
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="intfeature" type="intfeaturetype"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="stringfeature" type="stringfeaturetype"/>
+        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="producttype">
         <xs:sequence>
             <xs:element name="name" type="bt:stringtype"/>
             <xs:element name="version" type="bt:stringtype"/>
-            <xs:element name="related_product" type="producttype" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="features" type="productfeaturestype" minOccurs="0"/>
+            <xs:element name="related_product" type="producttype" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/tests/sample_models/orders/orders_ddl_mssql_version0.sql
+++ b/tests/sample_models/orders/orders_ddl_mssql_version0.sql
@@ -1,6 +1,7 @@
 
 CREATE TABLE orderperson (
 	pk_orderperson INTEGER NOT NULL IDENTITY, 
+	name_attr VARCHAR(1000) NULL, 
 	name VARCHAR(1000) NULL, 
 	address VARCHAR(1000) NULL, 
 	city VARCHAR(1000) NULL, 
@@ -10,6 +11,7 @@ CREATE TABLE orderperson (
 	[phoneNumber] VARCHAR(8000) NULL, 
 	[companyId_type] CHAR(3) NULL, 
 	[companyId_value] VARCHAR(1000) NULL, 
+	coordinates VARCHAR(1000) NULL, 
 	record_hash BINARY(20) NULL, 
 	CONSTRAINT cx_pk_orderperson PRIMARY KEY CLUSTERED (pk_orderperson), 
 	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (record_hash)

--- a/tests/sample_models/orders/orders_ddl_mssql_version0.sql
+++ b/tests/sample_models/orders/orders_ddl_mssql_version0.sql
@@ -18,6 +18,26 @@ CREATE TABLE orderperson (
 )
 
 
+CREATE TABLE intfeature (
+	pk_intfeature INTEGER NOT NULL IDENTITY, 
+	id VARCHAR(1000) NULL, 
+	value INTEGER NULL, 
+	record_hash BINARY(20) NULL, 
+	CONSTRAINT cx_pk_intfeature PRIMARY KEY CLUSTERED (pk_intfeature), 
+	CONSTRAINT intfeature_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE stringfeature (
+	pk_stringfeature INTEGER NOT NULL IDENTITY, 
+	id VARCHAR(1000) NULL, 
+	value VARCHAR(1000) NULL, 
+	record_hash BINARY(20) NULL, 
+	CONSTRAINT cx_pk_stringfeature PRIMARY KEY CLUSTERED (pk_stringfeature), 
+	CONSTRAINT stringfeature_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
 CREATE TABLE item (
 	pk_item INTEGER NOT NULL IDENTITY, 
 	product_name VARCHAR(1000) NULL, 
@@ -29,6 +49,22 @@ CREATE TABLE item (
 	record_hash BINARY(20) NULL, 
 	CONSTRAINT cx_pk_item PRIMARY KEY CLUSTERED (pk_item), 
 	CONSTRAINT item_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE item_product_features_intfeature (
+	fk_item INTEGER NOT NULL, 
+	fk_intfeature INTEGER NOT NULL, 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item), 
+	FOREIGN KEY(fk_intfeature) REFERENCES intfeature (pk_intfeature)
+)
+
+
+CREATE TABLE item_product_features_stringfeature (
+	fk_item INTEGER NOT NULL, 
+	fk_stringfeature INTEGER NOT NULL, 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item), 
+	FOREIGN KEY(fk_stringfeature) REFERENCES stringfeature (pk_stringfeature)
 )
 
 
@@ -71,6 +107,14 @@ CREATE TABLE orders_shiporder (
 	FOREIGN KEY(fk_orders) REFERENCES orders (pk_orders), 
 	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder)
 )
+
+CREATE CLUSTERED INDEX ix_fk_item_product_features_intfeature ON item_product_features_intfeature (fk_item, fk_intfeature)
+
+CREATE INDEX ix_item_product_features_intfeature_fk_intfeature ON item_product_features_intfeature (fk_intfeature)
+
+CREATE CLUSTERED INDEX ix_fk_item_product_features_stringfeature ON item_product_features_stringfeature (fk_item, fk_stringfeature)
+
+CREATE INDEX ix_item_product_features_stringfeature_fk_stringfeature ON item_product_features_stringfeature (fk_stringfeature)
 
 CREATE CLUSTERED INDEX ix_fk_shiporder_item ON shiporder_item (fk_shiporder, fk_item)
 

--- a/tests/sample_models/orders/orders_ddl_mssql_version1.sql
+++ b/tests/sample_models/orders/orders_ddl_mssql_version1.sql
@@ -1,6 +1,7 @@
 
 CREATE TABLE orderperson (
 	pk_orderperson INTEGER NOT NULL IDENTITY, 
+	name_attr VARCHAR(1000) NULL, 
 	name VARCHAR(1000) NULL, 
 	address VARCHAR(1000) NULL, 
 	city VARCHAR(1000) NULL, 
@@ -11,6 +12,7 @@ CREATE TABLE orderperson (
 	[companyId_ace] VARCHAR(1000) NULL, 
 	[companyId_bic] VARCHAR(1000) NULL, 
 	[companyId_lei] VARCHAR(1000) NULL, 
+	coordinates VARCHAR(1000) NULL, 
 	record_hash BINARY(16) NULL, 
 	CONSTRAINT cx_pk_orderperson PRIMARY KEY CLUSTERED (pk_orderperson), 
 	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (record_hash)

--- a/tests/sample_models/orders/orders_ddl_mssql_version1.sql
+++ b/tests/sample_models/orders/orders_ddl_mssql_version1.sql
@@ -19,6 +19,26 @@ CREATE TABLE orderperson (
 )
 
 
+CREATE TABLE intfeature (
+	pk_intfeature INTEGER NOT NULL IDENTITY, 
+	id VARCHAR(1000) NULL, 
+	value INTEGER NULL, 
+	record_hash BINARY(16) NULL, 
+	CONSTRAINT cx_pk_intfeature PRIMARY KEY CLUSTERED (pk_intfeature), 
+	CONSTRAINT intfeature_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE stringfeature (
+	pk_stringfeature INTEGER NOT NULL IDENTITY, 
+	id VARCHAR(1000) NULL, 
+	value VARCHAR(1000) NULL, 
+	record_hash BINARY(16) NULL, 
+	CONSTRAINT cx_pk_stringfeature PRIMARY KEY CLUSTERED (pk_stringfeature), 
+	CONSTRAINT stringfeature_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
 CREATE TABLE shiporder (
 	pk_shiporder INTEGER NOT NULL IDENTITY, 
 	orderid VARCHAR(1000) NULL, 
@@ -56,6 +76,7 @@ CREATE TABLE orders_shiporder (
 
 CREATE TABLE item (
 	pk_item INTEGER NOT NULL IDENTITY, 
+	temp_pk_item INTEGER NULL, 
 	fk_parent_shiporder INTEGER NULL, 
 	xml2db_row_number INTEGER NOT NULL, 
 	product_name VARCHAR(1000) NULL, 
@@ -68,7 +89,33 @@ CREATE TABLE item (
 	FOREIGN KEY(fk_parent_shiporder) REFERENCES shiporder (pk_shiporder)
 )
 
+
+CREATE TABLE item_product_features_intfeature (
+	fk_item INTEGER NOT NULL, 
+	fk_intfeature INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item), 
+	FOREIGN KEY(fk_intfeature) REFERENCES intfeature (pk_intfeature)
+)
+
+
+CREATE TABLE item_product_features_stringfeature (
+	fk_item INTEGER NOT NULL, 
+	fk_stringfeature INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item), 
+	FOREIGN KEY(fk_stringfeature) REFERENCES stringfeature (pk_stringfeature)
+)
+
 CREATE CLUSTERED INDEX ix_fk_orders_shiporder ON orders_shiporder (fk_orders, fk_shiporder)
 
 CREATE INDEX ix_orders_shiporder_fk_shiporder ON orders_shiporder (fk_shiporder)
+
+CREATE CLUSTERED INDEX ix_fk_item_product_features_intfeature ON item_product_features_intfeature (fk_item, fk_intfeature)
+
+CREATE INDEX ix_item_product_features_intfeature_fk_intfeature ON item_product_features_intfeature (fk_intfeature)
+
+CREATE CLUSTERED INDEX ix_fk_item_product_features_stringfeature ON item_product_features_stringfeature (fk_item, fk_stringfeature)
+
+CREATE INDEX ix_item_product_features_stringfeature_fk_stringfeature ON item_product_features_stringfeature (fk_stringfeature)
 

--- a/tests/sample_models/orders/orders_ddl_mssql_version2.sql
+++ b/tests/sample_models/orders/orders_ddl_mssql_version2.sql
@@ -12,6 +12,7 @@ CREATE TABLE orders (
 
 CREATE TABLE orderperson (
 	pk_orderperson INTEGER NOT NULL IDENTITY, 
+	name_attr VARCHAR(1000) NULL, 
 	name VARCHAR(1000) NULL, 
 	address VARCHAR(1000) NULL, 
 	city VARCHAR(1000) NULL, 
@@ -21,6 +22,7 @@ CREATE TABLE orderperson (
 	[phoneNumber] VARCHAR(8000) NULL, 
 	[companyId_type] CHAR(3) NULL, 
 	[companyId_value] VARCHAR(1000) NULL, 
+	coordinates VARCHAR(1000) NULL, 
 	xml2db_record_hash BINARY(20) NULL, 
 	CONSTRAINT cx_pk_orderperson PRIMARY KEY CLUSTERED (pk_orderperson), 
 	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (xml2db_record_hash)
@@ -57,6 +59,7 @@ CREATE TABLE shiporder (
 	fk_parent_orders INTEGER NULL, 
 	orderid VARCHAR(1000) NULL, 
 	processed_at DATETIMEOFFSET NULL, 
+	orderperson_name_attr VARCHAR(1000) NULL, 
 	orderperson_name VARCHAR(1000) NULL, 
 	orderperson_address VARCHAR(1000) NULL, 
 	orderperson_city VARCHAR(1000) NULL, 
@@ -66,6 +69,7 @@ CREATE TABLE shiporder (
 	[orderperson_phoneNumber] VARCHAR(8000) NULL, 
 	[orderperson_companyId_type] CHAR(3) NULL, 
 	[orderperson_companyId_value] VARCHAR(1000) NULL, 
+	orderperson_coordinates VARCHAR(1000) NULL, 
 	shipto_fk_orderperson INTEGER NULL, 
 	CONSTRAINT cx_pk_shiporder PRIMARY KEY CLUSTERED (pk_shiporder), 
 	FOREIGN KEY(fk_parent_orders) REFERENCES orders (pk_orders), 

--- a/tests/sample_models/orders/orders_ddl_mssql_version2.sql
+++ b/tests/sample_models/orders/orders_ddl_mssql_version2.sql
@@ -29,6 +29,26 @@ CREATE TABLE orderperson (
 )
 
 
+CREATE TABLE intfeature (
+	pk_intfeature INTEGER NOT NULL IDENTITY, 
+	id VARCHAR(1000) NULL, 
+	value INTEGER NULL, 
+	xml2db_record_hash BINARY(20) NULL, 
+	CONSTRAINT cx_pk_intfeature PRIMARY KEY CLUSTERED (pk_intfeature), 
+	CONSTRAINT intfeature_xml2db_record_hash UNIQUE (xml2db_record_hash)
+)
+
+
+CREATE TABLE stringfeature (
+	pk_stringfeature INTEGER NOT NULL IDENTITY, 
+	id VARCHAR(1000) NULL, 
+	value VARCHAR(1000) NULL, 
+	xml2db_record_hash BINARY(20) NULL, 
+	CONSTRAINT cx_pk_stringfeature PRIMARY KEY CLUSTERED (pk_stringfeature), 
+	CONSTRAINT stringfeature_xml2db_record_hash UNIQUE (xml2db_record_hash)
+)
+
+
 CREATE TABLE product (
 	pk_product INTEGER NOT NULL IDENTITY, 
 	name VARCHAR(1000) NULL, 
@@ -36,6 +56,22 @@ CREATE TABLE product (
 	xml2db_record_hash BINARY(20) NULL, 
 	CONSTRAINT cx_pk_product PRIMARY KEY CLUSTERED (pk_product), 
 	CONSTRAINT product_xml2db_record_hash UNIQUE (xml2db_record_hash)
+)
+
+
+CREATE TABLE product_features_intfeature (
+	fk_product INTEGER NOT NULL, 
+	fk_intfeature INTEGER NOT NULL, 
+	FOREIGN KEY(fk_product) REFERENCES product (pk_product), 
+	FOREIGN KEY(fk_intfeature) REFERENCES intfeature (pk_intfeature)
+)
+
+
+CREATE TABLE product_features_stringfeature (
+	fk_product INTEGER NOT NULL, 
+	fk_stringfeature INTEGER NOT NULL, 
+	FOREIGN KEY(fk_product) REFERENCES product (pk_product), 
+	FOREIGN KEY(fk_stringfeature) REFERENCES stringfeature (pk_stringfeature)
 )
 
 
@@ -83,6 +119,14 @@ CREATE TABLE shiporder_item (
 	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder), 
 	FOREIGN KEY(fk_item) REFERENCES item (pk_item)
 )
+
+CREATE CLUSTERED INDEX ix_fk_product_features_intfeature ON product_features_intfeature (fk_product, fk_intfeature)
+
+CREATE INDEX ix_product_features_intfeature_fk_intfeature ON product_features_intfeature (fk_intfeature)
+
+CREATE CLUSTERED INDEX ix_fk_product_features_stringfeature ON product_features_stringfeature (fk_product, fk_stringfeature)
+
+CREATE INDEX ix_product_features_stringfeature_fk_stringfeature ON product_features_stringfeature (fk_stringfeature)
 
 CREATE CLUSTERED INDEX ix_fk_shiporder_item ON shiporder_item (fk_shiporder, fk_item)
 

--- a/tests/sample_models/orders/orders_ddl_mysql_version0.sql
+++ b/tests/sample_models/orders/orders_ddl_mysql_version0.sql
@@ -1,6 +1,7 @@
 
 CREATE TABLE orderperson (
 	pk_orderperson INTEGER NOT NULL AUTO_INCREMENT, 
+	name_attr VARCHAR(255), 
 	name VARCHAR(255), 
 	address VARCHAR(255), 
 	city VARCHAR(255), 
@@ -10,6 +11,7 @@ CREATE TABLE orderperson (
 	`phoneNumber` VARCHAR(4000), 
 	`companyId_type` VARCHAR(3), 
 	`companyId_value` VARCHAR(255), 
+	coordinates VARCHAR(255), 
 	record_hash BINARY(20), 
 	CONSTRAINT cx_pk_orderperson PRIMARY KEY (pk_orderperson), 
 	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (record_hash)

--- a/tests/sample_models/orders/orders_ddl_mysql_version0.sql
+++ b/tests/sample_models/orders/orders_ddl_mysql_version0.sql
@@ -18,6 +18,26 @@ CREATE TABLE orderperson (
 )
 
 
+CREATE TABLE intfeature (
+	pk_intfeature INTEGER NOT NULL AUTO_INCREMENT, 
+	id VARCHAR(255), 
+	value INTEGER, 
+	record_hash BINARY(20), 
+	CONSTRAINT cx_pk_intfeature PRIMARY KEY (pk_intfeature), 
+	CONSTRAINT intfeature_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE stringfeature (
+	pk_stringfeature INTEGER NOT NULL AUTO_INCREMENT, 
+	id VARCHAR(255), 
+	value VARCHAR(255), 
+	record_hash BINARY(20), 
+	CONSTRAINT cx_pk_stringfeature PRIMARY KEY (pk_stringfeature), 
+	CONSTRAINT stringfeature_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
 CREATE TABLE item (
 	pk_item INTEGER NOT NULL AUTO_INCREMENT, 
 	product_name VARCHAR(255), 
@@ -29,6 +49,22 @@ CREATE TABLE item (
 	record_hash BINARY(20), 
 	CONSTRAINT cx_pk_item PRIMARY KEY (pk_item), 
 	CONSTRAINT item_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE item_product_features_intfeature (
+	fk_item INTEGER NOT NULL, 
+	fk_intfeature INTEGER NOT NULL, 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item), 
+	FOREIGN KEY(fk_intfeature) REFERENCES intfeature (pk_intfeature)
+)
+
+
+CREATE TABLE item_product_features_stringfeature (
+	fk_item INTEGER NOT NULL, 
+	fk_stringfeature INTEGER NOT NULL, 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item), 
+	FOREIGN KEY(fk_stringfeature) REFERENCES stringfeature (pk_stringfeature)
 )
 
 
@@ -71,6 +107,14 @@ CREATE TABLE orders_shiporder (
 	FOREIGN KEY(fk_orders) REFERENCES orders (pk_orders), 
 	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder)
 )
+
+CREATE INDEX ix_item_product_features_intfeature_fk_intfeature ON item_product_features_intfeature (fk_intfeature)
+
+CREATE INDEX ix_item_product_features_intfeature_fk_item ON item_product_features_intfeature (fk_item)
+
+CREATE INDEX ix_item_product_features_stringfeature_fk_item ON item_product_features_stringfeature (fk_item)
+
+CREATE INDEX ix_item_product_features_stringfeature_fk_stringfeature ON item_product_features_stringfeature (fk_stringfeature)
 
 CREATE INDEX ix_shiporder_item_fk_item ON shiporder_item (fk_item)
 

--- a/tests/sample_models/orders/orders_ddl_mysql_version1.sql
+++ b/tests/sample_models/orders/orders_ddl_mysql_version1.sql
@@ -19,6 +19,26 @@ CREATE TABLE orderperson (
 )
 
 
+CREATE TABLE intfeature (
+	pk_intfeature INTEGER NOT NULL AUTO_INCREMENT, 
+	id VARCHAR(255), 
+	value INTEGER, 
+	record_hash BINARY(16), 
+	CONSTRAINT cx_pk_intfeature PRIMARY KEY (pk_intfeature), 
+	CONSTRAINT intfeature_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE stringfeature (
+	pk_stringfeature INTEGER NOT NULL AUTO_INCREMENT, 
+	id VARCHAR(255), 
+	value VARCHAR(255), 
+	record_hash BINARY(16), 
+	CONSTRAINT cx_pk_stringfeature PRIMARY KEY (pk_stringfeature), 
+	CONSTRAINT stringfeature_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
 CREATE TABLE shiporder (
 	pk_shiporder INTEGER NOT NULL AUTO_INCREMENT, 
 	orderid VARCHAR(255), 
@@ -56,6 +76,7 @@ CREATE TABLE orders_shiporder (
 
 CREATE TABLE item (
 	pk_item INTEGER NOT NULL AUTO_INCREMENT, 
+	temp_pk_item INTEGER, 
 	fk_parent_shiporder INTEGER, 
 	xml2db_row_number INTEGER NOT NULL, 
 	product_name VARCHAR(255), 
@@ -68,7 +89,33 @@ CREATE TABLE item (
 	FOREIGN KEY(fk_parent_shiporder) REFERENCES shiporder (pk_shiporder)
 )
 
+
+CREATE TABLE item_product_features_intfeature (
+	fk_item INTEGER NOT NULL, 
+	fk_intfeature INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item), 
+	FOREIGN KEY(fk_intfeature) REFERENCES intfeature (pk_intfeature)
+)
+
+
+CREATE TABLE item_product_features_stringfeature (
+	fk_item INTEGER NOT NULL, 
+	fk_stringfeature INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item), 
+	FOREIGN KEY(fk_stringfeature) REFERENCES stringfeature (pk_stringfeature)
+)
+
 CREATE INDEX ix_orders_shiporder_fk_orders ON orders_shiporder (fk_orders)
 
 CREATE INDEX ix_orders_shiporder_fk_shiporder ON orders_shiporder (fk_shiporder)
+
+CREATE INDEX ix_item_product_features_intfeature_fk_intfeature ON item_product_features_intfeature (fk_intfeature)
+
+CREATE INDEX ix_item_product_features_intfeature_fk_item ON item_product_features_intfeature (fk_item)
+
+CREATE INDEX ix_item_product_features_stringfeature_fk_item ON item_product_features_stringfeature (fk_item)
+
+CREATE INDEX ix_item_product_features_stringfeature_fk_stringfeature ON item_product_features_stringfeature (fk_stringfeature)
 

--- a/tests/sample_models/orders/orders_ddl_mysql_version1.sql
+++ b/tests/sample_models/orders/orders_ddl_mysql_version1.sql
@@ -1,6 +1,7 @@
 
 CREATE TABLE orderperson (
 	pk_orderperson INTEGER NOT NULL AUTO_INCREMENT, 
+	name_attr VARCHAR(255), 
 	name VARCHAR(255), 
 	address VARCHAR(255), 
 	city VARCHAR(255), 
@@ -11,6 +12,7 @@ CREATE TABLE orderperson (
 	`companyId_ace` VARCHAR(255), 
 	`companyId_bic` VARCHAR(255), 
 	`companyId_lei` VARCHAR(255), 
+	coordinates VARCHAR(255), 
 	record_hash BINARY(16), 
 	CONSTRAINT cx_pk_orderperson PRIMARY KEY (pk_orderperson), 
 	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (record_hash)

--- a/tests/sample_models/orders/orders_ddl_mysql_version2.sql
+++ b/tests/sample_models/orders/orders_ddl_mysql_version2.sql
@@ -12,6 +12,7 @@ CREATE TABLE orders (
 
 CREATE TABLE orderperson (
 	pk_orderperson INTEGER NOT NULL AUTO_INCREMENT, 
+	name_attr VARCHAR(255), 
 	name VARCHAR(255), 
 	address VARCHAR(255), 
 	city VARCHAR(255), 
@@ -21,6 +22,7 @@ CREATE TABLE orderperson (
 	`phoneNumber` VARCHAR(4000), 
 	`companyId_type` VARCHAR(3), 
 	`companyId_value` VARCHAR(255), 
+	coordinates VARCHAR(255), 
 	xml2db_record_hash BINARY(20), 
 	CONSTRAINT cx_pk_orderperson PRIMARY KEY (pk_orderperson), 
 	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (xml2db_record_hash)
@@ -57,6 +59,7 @@ CREATE TABLE shiporder (
 	fk_parent_orders INTEGER, 
 	orderid VARCHAR(255), 
 	processed_at DATETIME, 
+	orderperson_name_attr VARCHAR(255), 
 	orderperson_name VARCHAR(255), 
 	orderperson_address VARCHAR(255), 
 	orderperson_city VARCHAR(255), 
@@ -66,6 +69,7 @@ CREATE TABLE shiporder (
 	`orderperson_phoneNumber` VARCHAR(4000), 
 	`orderperson_companyId_type` VARCHAR(3), 
 	`orderperson_companyId_value` VARCHAR(255), 
+	orderperson_coordinates VARCHAR(255), 
 	shipto_fk_orderperson INTEGER, 
 	CONSTRAINT cx_pk_shiporder PRIMARY KEY (pk_shiporder), 
 	FOREIGN KEY(fk_parent_orders) REFERENCES orders (pk_orders), 

--- a/tests/sample_models/orders/orders_ddl_mysql_version2.sql
+++ b/tests/sample_models/orders/orders_ddl_mysql_version2.sql
@@ -29,6 +29,26 @@ CREATE TABLE orderperson (
 )
 
 
+CREATE TABLE intfeature (
+	pk_intfeature INTEGER NOT NULL AUTO_INCREMENT, 
+	id VARCHAR(255), 
+	value INTEGER, 
+	xml2db_record_hash BINARY(20), 
+	CONSTRAINT cx_pk_intfeature PRIMARY KEY (pk_intfeature), 
+	CONSTRAINT intfeature_xml2db_record_hash UNIQUE (xml2db_record_hash)
+)
+
+
+CREATE TABLE stringfeature (
+	pk_stringfeature INTEGER NOT NULL AUTO_INCREMENT, 
+	id VARCHAR(255), 
+	value VARCHAR(255), 
+	xml2db_record_hash BINARY(20), 
+	CONSTRAINT cx_pk_stringfeature PRIMARY KEY (pk_stringfeature), 
+	CONSTRAINT stringfeature_xml2db_record_hash UNIQUE (xml2db_record_hash)
+)
+
+
 CREATE TABLE product (
 	pk_product INTEGER NOT NULL AUTO_INCREMENT, 
 	name VARCHAR(255), 
@@ -36,6 +56,22 @@ CREATE TABLE product (
 	xml2db_record_hash BINARY(20), 
 	CONSTRAINT cx_pk_product PRIMARY KEY (pk_product), 
 	CONSTRAINT product_xml2db_record_hash UNIQUE (xml2db_record_hash)
+)
+
+
+CREATE TABLE product_features_intfeature (
+	fk_product INTEGER NOT NULL, 
+	fk_intfeature INTEGER NOT NULL, 
+	FOREIGN KEY(fk_product) REFERENCES product (pk_product), 
+	FOREIGN KEY(fk_intfeature) REFERENCES intfeature (pk_intfeature)
+)
+
+
+CREATE TABLE product_features_stringfeature (
+	fk_product INTEGER NOT NULL, 
+	fk_stringfeature INTEGER NOT NULL, 
+	FOREIGN KEY(fk_product) REFERENCES product (pk_product), 
+	FOREIGN KEY(fk_stringfeature) REFERENCES stringfeature (pk_stringfeature)
 )
 
 
@@ -83,6 +119,14 @@ CREATE TABLE shiporder_item (
 	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder), 
 	FOREIGN KEY(fk_item) REFERENCES item (pk_item)
 )
+
+CREATE INDEX ix_product_features_intfeature_fk_intfeature ON product_features_intfeature (fk_intfeature)
+
+CREATE INDEX ix_product_features_intfeature_fk_product ON product_features_intfeature (fk_product)
+
+CREATE INDEX ix_product_features_stringfeature_fk_product ON product_features_stringfeature (fk_product)
+
+CREATE INDEX ix_product_features_stringfeature_fk_stringfeature ON product_features_stringfeature (fk_stringfeature)
 
 CREATE INDEX ix_shiporder_item_fk_item ON shiporder_item (fk_item)
 

--- a/tests/sample_models/orders/orders_ddl_postgresql_version0.sql
+++ b/tests/sample_models/orders/orders_ddl_postgresql_version0.sql
@@ -1,6 +1,7 @@
 
 CREATE TABLE orderperson (
 	pk_orderperson SERIAL NOT NULL, 
+	name_attr VARCHAR(1000), 
 	name VARCHAR(1000), 
 	address VARCHAR(1000), 
 	city VARCHAR(1000), 
@@ -10,6 +11,7 @@ CREATE TABLE orderperson (
 	"phoneNumber" VARCHAR(8000), 
 	"companyId_type" VARCHAR(3), 
 	"companyId_value" VARCHAR(1000), 
+	coordinates VARCHAR(1000), 
 	record_hash BYTEA, 
 	CONSTRAINT cx_pk_orderperson PRIMARY KEY (pk_orderperson), 
 	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (record_hash)

--- a/tests/sample_models/orders/orders_ddl_postgresql_version0.sql
+++ b/tests/sample_models/orders/orders_ddl_postgresql_version0.sql
@@ -18,6 +18,26 @@ CREATE TABLE orderperson (
 )
 
 
+CREATE TABLE intfeature (
+	pk_intfeature SERIAL NOT NULL, 
+	id VARCHAR(1000), 
+	value INTEGER, 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_intfeature PRIMARY KEY (pk_intfeature), 
+	CONSTRAINT intfeature_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE stringfeature (
+	pk_stringfeature SERIAL NOT NULL, 
+	id VARCHAR(1000), 
+	value VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_stringfeature PRIMARY KEY (pk_stringfeature), 
+	CONSTRAINT stringfeature_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
 CREATE TABLE item (
 	pk_item SERIAL NOT NULL, 
 	product_name VARCHAR(1000), 
@@ -29,6 +49,22 @@ CREATE TABLE item (
 	record_hash BYTEA, 
 	CONSTRAINT cx_pk_item PRIMARY KEY (pk_item), 
 	CONSTRAINT item_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE item_product_features_intfeature (
+	fk_item INTEGER NOT NULL, 
+	fk_intfeature INTEGER NOT NULL, 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item), 
+	FOREIGN KEY(fk_intfeature) REFERENCES intfeature (pk_intfeature)
+)
+
+
+CREATE TABLE item_product_features_stringfeature (
+	fk_item INTEGER NOT NULL, 
+	fk_stringfeature INTEGER NOT NULL, 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item), 
+	FOREIGN KEY(fk_stringfeature) REFERENCES stringfeature (pk_stringfeature)
 )
 
 
@@ -71,6 +107,14 @@ CREATE TABLE orders_shiporder (
 	FOREIGN KEY(fk_orders) REFERENCES orders (pk_orders), 
 	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder)
 )
+
+CREATE INDEX ix_item_product_features_intfeature_fk_intfeature ON item_product_features_intfeature (fk_intfeature)
+
+CREATE INDEX ix_item_product_features_intfeature_fk_item ON item_product_features_intfeature (fk_item)
+
+CREATE INDEX ix_item_product_features_stringfeature_fk_item ON item_product_features_stringfeature (fk_item)
+
+CREATE INDEX ix_item_product_features_stringfeature_fk_stringfeature ON item_product_features_stringfeature (fk_stringfeature)
 
 CREATE INDEX ix_shiporder_item_fk_item ON shiporder_item (fk_item)
 

--- a/tests/sample_models/orders/orders_ddl_postgresql_version1.sql
+++ b/tests/sample_models/orders/orders_ddl_postgresql_version1.sql
@@ -1,6 +1,7 @@
 
 CREATE TABLE orderperson (
 	pk_orderperson SERIAL NOT NULL, 
+	name_attr VARCHAR(1000), 
 	name VARCHAR(1000), 
 	address VARCHAR(1000), 
 	city VARCHAR(1000), 
@@ -11,6 +12,7 @@ CREATE TABLE orderperson (
 	"companyId_ace" VARCHAR(1000), 
 	"companyId_bic" VARCHAR(1000), 
 	"companyId_lei" VARCHAR(1000), 
+	coordinates VARCHAR(1000), 
 	record_hash BYTEA, 
 	CONSTRAINT cx_pk_orderperson PRIMARY KEY (pk_orderperson), 
 	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (record_hash)

--- a/tests/sample_models/orders/orders_ddl_postgresql_version1.sql
+++ b/tests/sample_models/orders/orders_ddl_postgresql_version1.sql
@@ -19,6 +19,26 @@ CREATE TABLE orderperson (
 )
 
 
+CREATE TABLE intfeature (
+	pk_intfeature SERIAL NOT NULL, 
+	id VARCHAR(1000), 
+	value INTEGER, 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_intfeature PRIMARY KEY (pk_intfeature), 
+	CONSTRAINT intfeature_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
+CREATE TABLE stringfeature (
+	pk_stringfeature SERIAL NOT NULL, 
+	id VARCHAR(1000), 
+	value VARCHAR(1000), 
+	record_hash BYTEA, 
+	CONSTRAINT cx_pk_stringfeature PRIMARY KEY (pk_stringfeature), 
+	CONSTRAINT stringfeature_xml2db_record_hash UNIQUE (record_hash)
+)
+
+
 CREATE TABLE shiporder (
 	pk_shiporder SERIAL NOT NULL, 
 	orderid VARCHAR(1000), 
@@ -56,6 +76,7 @@ CREATE TABLE orders_shiporder (
 
 CREATE TABLE item (
 	pk_item SERIAL NOT NULL, 
+	temp_pk_item INTEGER, 
 	fk_parent_shiporder INTEGER, 
 	xml2db_row_number INTEGER NOT NULL, 
 	product_name VARCHAR(1000), 
@@ -68,7 +89,33 @@ CREATE TABLE item (
 	FOREIGN KEY(fk_parent_shiporder) REFERENCES shiporder (pk_shiporder)
 )
 
+
+CREATE TABLE item_product_features_intfeature (
+	fk_item INTEGER NOT NULL, 
+	fk_intfeature INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item), 
+	FOREIGN KEY(fk_intfeature) REFERENCES intfeature (pk_intfeature)
+)
+
+
+CREATE TABLE item_product_features_stringfeature (
+	fk_item INTEGER NOT NULL, 
+	fk_stringfeature INTEGER NOT NULL, 
+	xml2db_row_number INTEGER NOT NULL, 
+	FOREIGN KEY(fk_item) REFERENCES item (pk_item), 
+	FOREIGN KEY(fk_stringfeature) REFERENCES stringfeature (pk_stringfeature)
+)
+
 CREATE INDEX ix_orders_shiporder_fk_orders ON orders_shiporder (fk_orders)
 
 CREATE INDEX ix_orders_shiporder_fk_shiporder ON orders_shiporder (fk_shiporder)
+
+CREATE INDEX ix_item_product_features_intfeature_fk_intfeature ON item_product_features_intfeature (fk_intfeature)
+
+CREATE INDEX ix_item_product_features_intfeature_fk_item ON item_product_features_intfeature (fk_item)
+
+CREATE INDEX ix_item_product_features_stringfeature_fk_item ON item_product_features_stringfeature (fk_item)
+
+CREATE INDEX ix_item_product_features_stringfeature_fk_stringfeature ON item_product_features_stringfeature (fk_stringfeature)
 

--- a/tests/sample_models/orders/orders_ddl_postgresql_version2.sql
+++ b/tests/sample_models/orders/orders_ddl_postgresql_version2.sql
@@ -12,6 +12,7 @@ CREATE TABLE orders (
 
 CREATE TABLE orderperson (
 	pk_orderperson SERIAL NOT NULL, 
+	name_attr VARCHAR(1000), 
 	name VARCHAR(1000), 
 	address VARCHAR(1000), 
 	city VARCHAR(1000), 
@@ -21,6 +22,7 @@ CREATE TABLE orderperson (
 	"phoneNumber" VARCHAR(8000), 
 	"companyId_type" VARCHAR(3), 
 	"companyId_value" VARCHAR(1000), 
+	coordinates VARCHAR(1000), 
 	xml2db_record_hash BYTEA, 
 	CONSTRAINT cx_pk_orderperson PRIMARY KEY (pk_orderperson), 
 	CONSTRAINT orderperson_xml2db_record_hash UNIQUE (xml2db_record_hash)
@@ -57,6 +59,7 @@ CREATE TABLE shiporder (
 	fk_parent_orders INTEGER, 
 	orderid VARCHAR(1000), 
 	processed_at TIMESTAMP WITH TIME ZONE, 
+	orderperson_name_attr VARCHAR(1000), 
 	orderperson_name VARCHAR(1000), 
 	orderperson_address VARCHAR(1000), 
 	orderperson_city VARCHAR(1000), 
@@ -66,6 +69,7 @@ CREATE TABLE shiporder (
 	"orderperson_phoneNumber" VARCHAR(8000), 
 	"orderperson_companyId_type" VARCHAR(3), 
 	"orderperson_companyId_value" VARCHAR(1000), 
+	orderperson_coordinates VARCHAR(1000), 
 	shipto_fk_orderperson INTEGER, 
 	CONSTRAINT cx_pk_shiporder PRIMARY KEY (pk_shiporder), 
 	FOREIGN KEY(fk_parent_orders) REFERENCES orders (pk_orders), 

--- a/tests/sample_models/orders/orders_ddl_postgresql_version2.sql
+++ b/tests/sample_models/orders/orders_ddl_postgresql_version2.sql
@@ -29,6 +29,26 @@ CREATE TABLE orderperson (
 )
 
 
+CREATE TABLE intfeature (
+	pk_intfeature SERIAL NOT NULL, 
+	id VARCHAR(1000), 
+	value INTEGER, 
+	xml2db_record_hash BYTEA, 
+	CONSTRAINT cx_pk_intfeature PRIMARY KEY (pk_intfeature), 
+	CONSTRAINT intfeature_xml2db_record_hash UNIQUE (xml2db_record_hash)
+)
+
+
+CREATE TABLE stringfeature (
+	pk_stringfeature SERIAL NOT NULL, 
+	id VARCHAR(1000), 
+	value VARCHAR(1000), 
+	xml2db_record_hash BYTEA, 
+	CONSTRAINT cx_pk_stringfeature PRIMARY KEY (pk_stringfeature), 
+	CONSTRAINT stringfeature_xml2db_record_hash UNIQUE (xml2db_record_hash)
+)
+
+
 CREATE TABLE product (
 	pk_product SERIAL NOT NULL, 
 	name VARCHAR(1000), 
@@ -36,6 +56,22 @@ CREATE TABLE product (
 	xml2db_record_hash BYTEA, 
 	CONSTRAINT cx_pk_product PRIMARY KEY (pk_product), 
 	CONSTRAINT product_xml2db_record_hash UNIQUE (xml2db_record_hash)
+)
+
+
+CREATE TABLE product_features_intfeature (
+	fk_product INTEGER NOT NULL, 
+	fk_intfeature INTEGER NOT NULL, 
+	FOREIGN KEY(fk_product) REFERENCES product (pk_product), 
+	FOREIGN KEY(fk_intfeature) REFERENCES intfeature (pk_intfeature)
+)
+
+
+CREATE TABLE product_features_stringfeature (
+	fk_product INTEGER NOT NULL, 
+	fk_stringfeature INTEGER NOT NULL, 
+	FOREIGN KEY(fk_product) REFERENCES product (pk_product), 
+	FOREIGN KEY(fk_stringfeature) REFERENCES stringfeature (pk_stringfeature)
 )
 
 
@@ -83,6 +119,14 @@ CREATE TABLE shiporder_item (
 	FOREIGN KEY(fk_shiporder) REFERENCES shiporder (pk_shiporder), 
 	FOREIGN KEY(fk_item) REFERENCES item (pk_item)
 )
+
+CREATE INDEX ix_product_features_intfeature_fk_intfeature ON product_features_intfeature (fk_intfeature)
+
+CREATE INDEX ix_product_features_intfeature_fk_product ON product_features_intfeature (fk_product)
+
+CREATE INDEX ix_product_features_stringfeature_fk_product ON product_features_stringfeature (fk_product)
+
+CREATE INDEX ix_product_features_stringfeature_fk_stringfeature ON product_features_stringfeature (fk_stringfeature)
 
 CREATE INDEX ix_shiporder_item_fk_item ON shiporder_item (fk_item)
 

--- a/tests/sample_models/orders/orders_erd_version0.md
+++ b/tests/sample_models/orders/orders_erd_version0.md
@@ -12,6 +12,8 @@ erDiagram
         string orderid
         dateTime processed_at
     }
+    item ||--o{ intfeature : "product_features_intfeature*"
+    item ||--o{ stringfeature : "product_features_stringfeature*"
     item {
         string product_name
         string product_version
@@ -19,6 +21,14 @@ erDiagram
         integer quantity
         decimal price
         string currency
+    }
+    stringfeature {
+        string id
+        string value
+    }
+    intfeature {
+        string id
+        integer value
     }
     orderperson {
         string name_attr

--- a/tests/sample_models/orders/orders_erd_version0.md
+++ b/tests/sample_models/orders/orders_erd_version0.md
@@ -21,6 +21,7 @@ erDiagram
         string currency
     }
     orderperson {
+        string name_attr
         string name
         string address
         string city
@@ -30,5 +31,6 @@ erDiagram
         string-N phoneNumber
         string companyId_type
         string companyId_value
+        string coordinates
     }
 ```

--- a/tests/sample_models/orders/orders_erd_version1.md
+++ b/tests/sample_models/orders/orders_erd_version1.md
@@ -21,6 +21,7 @@ erDiagram
         dateTime processed_at
     }
     orderperson {
+        string name_attr
         string name
         string address
         string city
@@ -31,5 +32,6 @@ erDiagram
         string companyId_ace
         string companyId_bic
         string companyId_lei
+        string coordinates
     }
 ```

--- a/tests/sample_models/orders/orders_erd_version1.md
+++ b/tests/sample_models/orders/orders_erd_version1.md
@@ -1,5 +1,7 @@
 ```mermaid
 erDiagram
+    item ||--o{ intfeature : "product_features_intfeature*"
+    item ||--o{ stringfeature : "product_features_stringfeature*"
     item {
         string product_name
         string product_version
@@ -19,6 +21,14 @@ erDiagram
     shiporder {
         string orderid
         dateTime processed_at
+    }
+    stringfeature {
+        string id
+        string value
+    }
+    intfeature {
+        string id
+        integer value
     }
     orderperson {
         string name_attr

--- a/tests/sample_models/orders/orders_erd_version2.md
+++ b/tests/sample_models/orders/orders_erd_version2.md
@@ -24,9 +24,19 @@ erDiagram
         decimal price
         string currency
     }
+    product ||--o{ intfeature : "features_intfeature*"
+    product ||--o{ stringfeature : "features_stringfeature*"
     product {
         string name
         string version
+    }
+    stringfeature {
+        string id
+        string value
+    }
+    intfeature {
+        string id
+        integer value
     }
     orderperson {
         string name_attr

--- a/tests/sample_models/orders/orders_erd_version2.md
+++ b/tests/sample_models/orders/orders_erd_version2.md
@@ -5,6 +5,7 @@ erDiagram
     shiporder {
         string orderid
         dateTime processed_at
+        string orderperson_name_attr
         string orderperson_name
         string orderperson_address
         string orderperson_city
@@ -14,6 +15,7 @@ erDiagram
         string-N orderperson_phoneNumber
         string orderperson_companyId_type
         string orderperson_companyId_value
+        string orderperson_coordinates
     }
     item ||--|| product : "product"
     item {
@@ -27,6 +29,7 @@ erDiagram
         string version
     }
     orderperson {
+        string name_attr
         string name
         string address
         string city
@@ -36,6 +39,7 @@ erDiagram
         string-N phoneNumber
         string companyId_type
         string companyId_value
+        string coordinates
     }
     orders ||--o{ shiporder : "shiporder"
     orders {

--- a/tests/sample_models/orders/xml/order1.xml
+++ b/tests/sample_models/orders/xml/order1.xml
@@ -2,7 +2,7 @@
 <orders xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" batch_id="5" xsi:noNamespaceSchemaLocation="../orders.xsd">
   <version>2</version>
   <shiporder orderid="1" processed_at="2023-09-10T09:37:00.000+02:00">
-    <orderperson>
+    <orderperson name="billing">
       <name>Bob</name>
       <address>string</address>
       <city>string</city>

--- a/tests/sample_models/orders/xml/order2.xml
+++ b/tests/sample_models/orders/xml/order2.xml
@@ -2,7 +2,7 @@
 <orders xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" batch_id="2" xsi:noNamespaceSchemaLocation="../orders.xsd">
   <version>2</version>
   <shiporder orderid="2" processed_at="2023-09-10T09:39:45.000+02:00">
-    <orderperson>
+    <orderperson name="billing">
       <name>Alice</name>
       <address>string</address>
       <city>string</city>

--- a/tests/sample_models/orders/xml/order3.xml
+++ b/tests/sample_models/orders/xml/order3.xml
@@ -2,14 +2,14 @@
 <orders xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" batch_id="4" xsi:noNamespaceSchemaLocation="../orders.xsd">
   <version>2</version>
   <shiporder orderid="3" processed_at="2023-09-11T18:27:56.000+02:00">
-    <orderperson>
+    <orderperson name="billing">
       <name>Alice</name>
       <address>string</address>
       <city>string</city>
       <zip codingSystem="int">21093</zip>
       <country>US</country>
     </orderperson>
-    <shipto>
+    <shipto name="shipping">
       <name>Bob</name>
       <address>string</address>
       <city>string</city>
@@ -20,6 +20,7 @@
       <companyId>
         <bic>JIDAZIO786DAZH</bic>
       </companyId>
+      <coordinates>48.87271337163929 2.323433844198471</coordinates>
     </shipto>
     <item>
       <product>

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -115,3 +115,29 @@ def test_document_tree_to_xml(test_config):
         ref_xml = f.read()
 
     assert xml == ref_xml
+
+
+@pytest.mark.parametrize(
+    "test_config",
+    [
+        {**model, **version}
+        for model in models
+        for version in model["versions"]
+        if os.path.isdir(os.path.join(models_path, model["id"], "equivalent_xml"))
+    ],
+)
+def test_equivalent_xml(test_config):
+    """A test for xml documents which should result in the same extracted data"""
+
+    xml_files = list_xml_path(test_config, "equivalent_xml")
+
+    if len(xml_files) > 1:
+        model = DataModel(
+            str(os.path.join(models_path, test_config["id"], test_config["xsd"])),
+            short_name=test_config["id"],
+            model_config=test_config["config"],
+        )
+        ref_data = model.parse_xml(xml_files[0])
+        for xml_file in xml_files[1:]:
+            equ_data = model.parse_xml(xml_file)
+            assert ref_data.data == equ_data.data

--- a/tests/test_models_output.py
+++ b/tests/test_models_output.py
@@ -5,6 +5,7 @@ from sqlalchemy.dialects import postgresql, mssql, mysql
 
 from xml2db import DataModel
 from .sample_models import models
+from .conftest import models_path
 
 
 @pytest.mark.parametrize(
@@ -19,14 +20,15 @@ def test_model_erd(test_config):
     """A test to check if generated ERD matches saved output"""
 
     model = DataModel(
-        test_config["xsd_path"],
+        str(os.path.join(models_path, test_config["id"], test_config["xsd"])),
         short_name=test_config["id"],
         model_config=test_config["config"],
     )
 
     expected = open(
         os.path.join(
-            os.path.dirname(test_config["xsd_path"]),
+            models_path,
+            test_config["id"],
             f"{test_config['id']}_erd_version{test_config['version_id']}.md",
         ),
         "r",
@@ -49,7 +51,7 @@ def test_model_ddl(test_config):
     """A test to check if generated SQL DDL matches saved output"""
 
     model = DataModel(
-        test_config["xsd_path"],
+        str(os.path.join(models_path, test_config["id"], test_config["xsd"])),
         short_name=test_config["id"],
         model_config=test_config["config"],
         db_type=test_config["dialect"].name,
@@ -57,7 +59,8 @@ def test_model_ddl(test_config):
 
     expected = open(
         os.path.join(
-            os.path.dirname(test_config["xsd_path"]),
+            models_path,
+            test_config["id"],
             f"{test_config['id']}_ddl_{test_config['dialect'].name}_version{test_config['version_id']}.sql",
         ),
         "r",

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -4,7 +4,7 @@ import pytest
 from lxml import etree
 
 from xml2db.xml_converter import XMLConverter, remove_record_hash
-from .fixtures import setup_db_model, conn_string
+from .conftest import list_xml_path
 from .sample_models import models
 
 
@@ -17,10 +17,7 @@ def test_database_xml_roundtrip(setup_db_model, model_config):
     """A test for roundtrip insert to the database from and to XML"""
 
     model = setup_db_model
-    xml_files = [
-        os.path.join(model_config["xml_path"], file)
-        for file in os.listdir(model_config["xml_path"])
-    ]
+    xml_files = list_xml_path(model_config, "xml")
 
     for file in xml_files:
         # do parse and insert into the database
@@ -59,10 +56,7 @@ def test_database_document_tree_roundtrip(setup_db_model, model_config):
     """A test for roundtrip insert to the database from and to document tree"""
 
     model = setup_db_model
-    xml_files = [
-        os.path.join(model_config["xml_path"], file)
-        for file in os.listdir(model_config["xml_path"])
-    ]
+    xml_files = list_xml_path(model_config, "xml")
 
     for file in xml_files:
         # do parse and insert into the database
@@ -92,10 +86,7 @@ def test_database_document_tree_roundtrip_single_load(setup_db_model, model_conf
     """A test for roundtrip insert to the database from and to document tree"""
 
     model = setup_db_model
-    xml_files = [
-        os.path.join(model_config["xml_path"], file)
-        for file in os.listdir(model_config["xml_path"])
-    ]
+    xml_files = list_xml_path(model_config, "xml")
 
     flat_data = None
     doc = None
@@ -129,7 +120,7 @@ def test_database_document_tree_roundtrip_single_load(setup_db_model, model_conf
     [
         {**model, **version, "xml_file": xml_file}
         for model in models
-        for xml_file in os.listdir(model["xml_path"])
+        for xml_file in list_xml_path(model, "xml")
         for version in model["versions"]
     ],
 )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,10 +1,10 @@
-import xml.etree.ElementTree
-
 import lxml.etree
 import pytest
+import os
 
 from xml2db import DataModel
 from .sample_models import models
+from .conftest import models_path
 
 
 @pytest.mark.parametrize(
@@ -27,7 +27,9 @@ from .sample_models import models
 def test_invalid_xml(args: tuple):
 
     file_name, iterparse, recover, exception = args
-    data_model = DataModel(models[0]["xsd_path"])
+    data_model = DataModel(
+        str(os.path.join(models_path, models[0]["id"], models[0]["xsd"]))
+    )
 
     if exception is None:
         data_model.parse_xml(
@@ -49,8 +51,8 @@ def test_invalid_xml(args: tuple):
 @pytest.mark.parametrize(
     "args",
     [
-        ("invalid", True, False, IndexError),
-        ("invalid", True, True, IndexError),
+        ("invalid", True, False, None),
+        ("invalid", True, True, None),
         ("invalid", False, False, None),
         ("invalid", False, True, None),
         ("malformed_recover", True, False, lxml.etree.XMLSyntaxError),
@@ -58,7 +60,7 @@ def test_invalid_xml(args: tuple):
         ("malformed_recover", False, False, lxml.etree.XMLSyntaxError),
         ("malformed_recover", False, True, None),
         ("malformed_no_recover", True, False, lxml.etree.XMLSyntaxError),
-        ("malformed_no_recover", True, True, IndexError),
+        ("malformed_no_recover", True, True, None),
         ("malformed_no_recover", False, False, lxml.etree.XMLSyntaxError),
         ("malformed_no_recover", False, True, None),
     ],
@@ -66,7 +68,9 @@ def test_invalid_xml(args: tuple):
 def test_invalid_xml_skip_verify(args: tuple):
 
     file_name, iterparse, recover, exception = args
-    data_model = DataModel(models[0]["xsd_path"])
+    data_model = DataModel(
+        str(os.path.join(models_path, models[0]["id"], models[0]["xsd"]))
+    )
 
     if exception is None:
         data_model.parse_xml(


### PR DESCRIPTION
A few fixes to solve issues discussed in #15:

* `short_name` is actually required in some cases despite being an optional argument -> set a default value
* support of recursive XSD definition -> propose a minimal support (e.g. not correct but does not fail) by dropping the fields that make the schema recursive
* support of `xsd:list` types added
* support of `complexTypes` with an attribute with the same name as an element of the same `complexType` added
* support of `sequence`s with unbounded `max_occurs` containing `element`s also with unbounded `max_occurs` 