### PR TITLE
feat: adds name shortening for relations & temp tables, test timezone handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ venv
 .spyproject
 .idea
 site
+.env
+uv.lock

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xml2db"
-version = "0.12.5"
+version = "0.12.6"
 authors = [
   { name="Commission de régulation de l'énergie", email="opensource@cre.fr" },
 ]
@@ -36,3 +36,6 @@ markers = [
     "dbtest: marks tests as integration tests requiring a database backend (deselect with '-m \"not dbtest\"')",
 ]
 junit_family = "xunit2"
+
+[tool.uv]
+package = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ paginate==0.5.7
 pathspec==0.12.1
 platformdirs==4.3.7
 pluggy==1.5.0
-psycopg2==2.9.10
+psycopg2-binary==2.9.10
 Pygments==2.19.1
 pymdown-extensions==10.14.3
 PyMySQL==1.1.1
@@ -42,6 +42,7 @@ requests==2.32.3
 six==1.17.0
 SQLAlchemy==2.0.40
 typing_extensions==4.13.1
+tzlocal==5.3.1
 urllib3==2.3.0
 watchdog==6.0.0
 xmlschema==3.4.5

--- a/src/xml2db/model.py
+++ b/src/xml2db/model.py
@@ -143,6 +143,8 @@ class DataModel:
             for key, exp_type, default in [
                 ("as_columnstore", bool, False),
                 ("row_numbers", bool, False),
+                ("shorten_temp_table_names", bool, False),
+                ("shorten_rel_table_names", bool, False),
                 ("document_tree_hook", callable, None),
                 ("document_tree_node_hook", callable, None),
                 ("record_hash_column_name", str, "xml2db_record_hash"),
@@ -194,6 +196,8 @@ class DataModel:
             A data model instance.
         """
         table_config = self.tables_config.get(table_name, {})
+        table_config["shorten_temp_table_names"] = self.model_config["shorten_temp_table_names"]
+        table_config["shorten_rel_table_names"] = self.model_config["shorten_rel_table_names"]
         if table_config.get("reuse", True):
             return DataModelTableReused(
                 table_name,

--- a/src/xml2db/table/duplicated_table.py
+++ b/src/xml2db/table/duplicated_table.py
@@ -119,9 +119,12 @@ class DataModelTableDuplicated(DataModelTableTransformed):
                 )
             )
 
+        temp_table_name = f"{prefix}{self.name}" 
+        temp_table_name = self.truncate_long_name(temp_table_name) if self.config.get("shorten_temp_table_names") else temp_table_name
+
         # build temporary table
         self.temp_table = Table(
-            f"{prefix}{self.name}",
+            temp_table_name,
             self.metadata,
             Column(f"pk_{self.name}", Integer),
             *get_col(temp=True),

--- a/src/xml2db/table/relations.py
+++ b/src/xml2db/table/relations.py
@@ -101,8 +101,11 @@ class DataModelRelationN(DataModelRelation):
         )
         prefix = f"temp_{self.table.temp_prefix}_"
         if self.other_table.is_reused:
+            temp_table_name = f"{prefix}{self.rel_table_name}" 
+            temp_table_name = self.table.truncate_long_name(temp_table_name) if self.table.config.get("shorten_temp_table_names") else temp_table_name
+            
             self.temp_rel_table = Table(
-                f"{prefix}{self.rel_table_name}",
+                temp_table_name,
                 self.table.metadata,
                 Column(f"temp_fk_{self.table.name}", Integer, nullable=False),
                 Column(f"fk_{self.table.name}", Integer),
@@ -132,8 +135,9 @@ class DataModelRelationN(DataModelRelation):
                     ),
                 )
 
+            table_name =  self.table.truncate_long_name(self.rel_table_name) if self.table.config.get("shorten_rel_table_names") else self.rel_table_name
             self.rel_table = Table(
-                self.rel_table_name,
+                table_name,
                 self.table.metadata,
                 Column(
                     f"fk_{self.table.name}",

--- a/src/xml2db/table/reused_table.py
+++ b/src/xml2db/table/reused_table.py
@@ -15,13 +15,11 @@ from sqlalchemy import (
 from .column import DataModelColumn
 from .transformed_table import DataModelTableTransformed
 
-
 def shorten_str(x: str, max_len: int = 30) -> str:
     if len(x) > max_len:
         h = sha1(x.encode("utf8"))
         return f"{x[:(max_len - 7)]}_{h.hexdigest()[1:6]}"
     return x
-
 
 class DataModelTableReused(DataModelTableTransformed):
     """A table data model which de-duplicates records in the database based on their hash value.
@@ -134,9 +132,12 @@ class DataModelTableReused(DataModelTableTransformed):
                 )
             )
 
+        temp_table_name = f"{prefix}{self.name}" 
+        temp_table_name = self.truncate_long_name(temp_table_name) if self.config.get("shorten_temp_table_names") else temp_table_name
+
         # build temporary table
         self.temp_table = Table(
-            f"{prefix}{self.name}",
+            temp_table_name,
             self.metadata,
             Column(f"pk_{self.name}", Integer),
             Column(

--- a/src/xml2db/table/table.py
+++ b/src/xml2db/table/table.py
@@ -1,3 +1,5 @@
+import hashlib
+import base64
 from typing import Iterable, List, Any, Union, TYPE_CHECKING
 import logging
 import sqlalchemy
@@ -12,7 +14,6 @@ if TYPE_CHECKING:
     from ..model import DataModel
 
 logger = logging.getLogger(__name__)
-
 
 class DataModelTable:
     """A class representing a database table translated from an XML schema complex type
@@ -99,6 +100,8 @@ class DataModelTable:
         config = {
             "reuse": check_type(cfg, "reuse", bool, True),
             "as_columnstore": check_type(cfg, "as_columnstore", bool, False),
+            "shorten_temp_table_names": check_type(cfg, "shorten_temp_table_names", bool, False),
+            "shorten_rel_table_names": check_type(cfg, "shorten_rel_table_names", bool, False)
         }
         if "extra_args" in cfg and not (
             isinstance(cfg["extra_args"], list)
@@ -117,7 +120,7 @@ class DataModelTable:
             logger.warning(
                 "Clustered columnstore indexes are only supported with MS SQL Server database"
             )
-
+        
         config["fields"] = cfg.get("fields", {})
 
         return config
@@ -324,10 +327,13 @@ class DataModelTable:
             temp: if True, create temporary (prefixed) tables
         """
         if temp:
+            logging.info(f"Creating temp table: {self.temp_table.name}")
             self.temp_table.create(engine, checkfirst=True)
         else:
+            logging.info(f"Creating table: {self.table.name}")
             self.table.create(engine, checkfirst=True)
         for relation in self.relations_n.values():
+            logging.info(f"Creating relation: {relation.name}")
             relation.create_table(engine, temp)
 
     def get_insert_temp_records_statements(
@@ -403,3 +409,55 @@ class DataModelTable:
             + ["}"]
         )
         return [f"    {line}" for line in out]
+    
+    def truncate_long_name(self, table_name: str) -> str:
+        max_len = 63 #both postgres and mysql safe table name len
+        new_name = table_name
+        
+        short_name = ""
+        shorter_name = ""
+        is_tmp = "temp" in table_name
+        suffix = f"_{hashlib.md5(table_name.encode('utf-8')).hexdigest()}"
+
+        if len(table_name) > max_len:
+            words = table_name.split("_")
+
+            for word in words:
+                if len(short_name) + len(word)<= (max_len - 1):
+                    if len(short_name) > 0: short_name += "_"
+                    short_name += f"{word}"
+                if len(shorter_name) + len(word) <= (max_len - 10):
+                    if len(shorter_name) > 0: shorter_name += "_"
+                    shorter_name += f"{word}"
+
+            #check if sliced name already exists:
+            sentinel = False
+            if is_tmp:
+                # just cut the name up and append the full suffix
+                # this doesn't need to be human readable / usable
+                short_name = short_name[:30]
+                sentinel = True
+            else:
+                for tbl in self.data_model.tables.values():
+                    if sentinel or tbl.name == short_name:
+                        sentinel = True
+                        break
+                    for relation in tbl.relations_n.values():
+                        if relation.rel_table_name == short_name:
+                            sentinel = True
+                            break
+            
+            # an existing table or relation was found: append a 
+            # random-ish suffix to help prevent name collisions
+            if sentinel:
+                # create a more useable/legible short table name
+                suffix = f"_{suffix[:8]}"
+                short_name = shorter_name
+            else:
+                # nothing was found so we can just run with the short name
+                suffix = ""
+
+            # finalize the new shortened name
+            new_name = f"{short_name}{suffix}"
+
+        return new_name

--- a/src/xml2db/table/transformed_table.py
+++ b/src/xml2db/table/transformed_table.py
@@ -5,7 +5,6 @@ from .column import DataModelColumn
 from .relations import DataModelRelation1, DataModelRelationN
 from .table import DataModelTable
 
-
 class DataModelTableTransformed(DataModelTable):
     """A class extending DataModelTable with transformations
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,4 +37,8 @@ def setup_db_model(conn_string, model_config):
 
     yield model
 
-    model.drop_all_tables()
+    try:
+        model.drop_all_tables()
+    except Exception as e:
+        print(f"Unable to drop all tables: {e}")
+        pass

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -7,6 +7,79 @@ from xml2db.xml_converter import XMLConverter, remove_record_hash
 from .conftest import list_xml_path
 from .sample_models import models
 
+import re
+import tzlocal 
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from typing import Any, Tuple
+
+# Regex for ISO-like datetime with timezone (adjust as needed)
+IANA_TZ = str(tzlocal.get_localzone())
+DATE_PATTERN = re.compile(
+    r'(\d{2}|\d{4})-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}\.\d{3}(?:[+-]\d{2}:\d{2}|Z)'
+)
+TIME_ZONE = os.environ.get("TIME_ZONE", IANA_TZ)
+
+def convert_date_string(date_str: str, to_tz: str) -> str:
+    # Normalize 'Z' to '+00:00'
+    if date_str.endswith('Z'):
+        date_str = date_str[:-1] + '+00:00'
+
+    year = 0
+    try:
+        dt = datetime.strptime(date_str, '%y-%m-%dT%H:%M:%S.%f%z')
+        year = 2
+    except:
+        try:
+            dt = datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%S.%f%z')
+            year = 4
+        except:
+            pass
+    
+    formatted = date_str
+    if year > 0:
+        # Convert to your desired timezone (example: US/Mountain)
+        target_tz = ZoneInfo(to_tz)
+        dt_new = dt.astimezone(target_tz)
+
+        # Format back to original string format
+        if year == 2:
+            formatted = dt_new.strftime('%y-%m-%dT%H:%M:%S.%f%z')
+        elif year == 4:
+            formatted = dt_new.strftime('%Y-%m-%dT%H:%M:%S.%f%z')
+
+        # Insert colon in timezone offset for ISO 8601 compliance
+        formatted = formatted[:-2] + ':' + formatted[-2:]
+        # Truncate microseconds to milliseconds
+        dot_idx = formatted.find('.')
+        if dot_idx != -1:
+            formatted = formatted[:dot_idx+4] + formatted[dot_idx+7:]
+
+    return formatted
+    
+def update_dates_in_tuple(data: Tuple[str, Any], to_tz: str) -> Tuple[str, Any]:
+    def update_dates(obj: Any, to_tz: str) -> Any:
+        if isinstance(obj, dict):
+            return {k: update_dates(v, to_tz) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [update_dates(item, to_tz) for item in obj]
+        elif isinstance(obj, tuple):
+            return tuple(update_dates(item, to_tz) for item in obj)
+        elif isinstance(obj, str) and DATE_PATTERN.match(obj):
+            try:
+                return convert_date_string(obj, to_tz)
+            except Exception:
+                return obj
+        else:
+            return obj
+
+    key, nested_dict = data
+    updated_dict = update_dates(nested_dict, to_tz)
+    return (key, updated_dict)
+
+def convert(match, tz=TIME_ZONE):
+    date_str = match.group()
+    return convert_date_string(date_str=date_str, to_tz=tz)
 
 @pytest.mark.dbtest
 @pytest.mark.parametrize(
@@ -26,7 +99,7 @@ def test_database_xml_roundtrip(setup_db_model, model_config):
 
     for file in xml_files:
         doc = model.extract_from_database(
-            f"input_file_path='{file}'", force_tz="Europe/Paris"
+            f"input_file_path='{file}'", force_tz=TIME_ZONE
         )
 
         with open(file, "rt") as f:
@@ -43,7 +116,8 @@ def test_database_xml_roundtrip(setup_db_model, model_config):
             encoding="utf-8",
             xml_declaration=True,
         ).decode("utf-8")
-
+        xml = re.sub(DATE_PATTERN, convert, xml)
+        ref_xml = re.sub(DATE_PATTERN, convert, ref_xml)
         assert xml == ref_xml
 
 
@@ -65,16 +139,16 @@ def test_database_document_tree_roundtrip(setup_db_model, model_config):
 
     for file in xml_files:
         doc = model.extract_from_database(
-            f"input_file_path='{file}'", force_tz="Europe/Paris"
+            f"input_file_path='{file}'", force_tz=TIME_ZONE
         )
 
         # parse file to doctree for reference
         converter = XMLConverter(model)
         converter.parse_xml(file, file)
 
-        assert doc.flat_data_to_doc_tree() == remove_record_hash(
+        assert update_dates_in_tuple(doc.flat_data_to_doc_tree(), TIME_ZONE) == update_dates_in_tuple(remove_record_hash(
             converter.document_tree
-        )
+        ), TIME_ZONE)
 
 
 @pytest.mark.dbtest
@@ -102,16 +176,16 @@ def test_database_document_tree_roundtrip_single_load(setup_db_model, model_conf
 
     for file in xml_files:
         doc = model.extract_from_database(
-            f"input_file_path='{file}'", force_tz="Europe/Paris"
+            f"input_file_path='{file}'", force_tz=TIME_ZONE
         )
 
         # parse file to doctree for reference
         converter = XMLConverter(model)
         converter.parse_xml(file, file)
 
-        assert doc.flat_data_to_doc_tree() == remove_record_hash(
+        assert update_dates_in_tuple(doc.flat_data_to_doc_tree(), TIME_ZONE) == update_dates_in_tuple(remove_record_hash(
             converter.document_tree
-        )
+        ), TIME_ZONE)
 
 
 @pytest.mark.skip
@@ -135,11 +209,13 @@ def test_database_single_document_tree_roundtrip(setup_db_model, model_config):
     doc.insert_into_target_tables()
 
     doc = model.extract_from_database(
-        f"input_file_path='{file_path}'", force_tz="Europe/Paris"
+        f"input_file_path='{file_path}'", force_tz=TIME_ZONE
     )
 
     # parse file to doctree for reference
     converter = XMLConverter(model)
     converter.parse_xml(file_path, file_path)
 
-    assert doc.flat_data_to_doc_tree() == remove_record_hash(converter.document_tree)
+    assert update_dates_in_tuple(doc.flat_data_to_doc_tree(), TIME_ZONE) == update_dates_in_tuple(remove_record_hash(
+        converter.document_tree
+    ), TIME_ZONE)


### PR DESCRIPTION
**Fixes:** 
- timezone failures in round trip tests caused by locale - adds TZ normalization to avoid false failures
- conftest.py: drop_all_tables fails due to sqlalchemy dropping dependencies out of order.  Avoids test failure by accepting that this may happen with a try/catch and notifying the developer.

**Features:**
- Add new model_config option: shorten_temp_table_names:  When true, long temp names (table, or relation table) will be truncated at 30 chars and appended with the MD5 hex digest of the name to ensure uniqueness of the name.  These are not human readable.  This is helpful especially for rel tables or table names that are close to the 2^6 char limit.

- Add new model_config option: shorten_rel_table_names: When true, long relation table names (for nested tags you can wind up with very long names even on simple table names) will be trimmed to the nearest word.  For instance if max_len is set to 20, the relation name table_foo_table_bar_baz would be trimmed to table_foo_table_bar.  If the name is not unique, the first 8 characters of the table name MD5 hex digest will be appended: table_foo_12345ABC.  This attempts to create human readable and usable names which are still unique and reflective of the relations.

In most cases these changes will prevent length based table creation failures without modifying the XSD schema.  This is helpful when the schema is not under the developer's control (e.g. provided by standards committee or other 3rd party).