### PR TITLE
Accept None values for table config

### DIFF
--- a/src/xml2db/model.py
+++ b/src/xml2db/model.py
@@ -194,6 +194,8 @@ class DataModel:
             A data model instance.
         """
         table_config = self.tables_config.get(table_name, {})
+        if table_config is None:
+            table_config = {}
         if table_config.get("reuse", True):
             return DataModelTableReused(
                 table_name,

--- a/tests/sample_models/models.py
+++ b/tests/sample_models/models.py
@@ -23,7 +23,8 @@ models = [
             {
                 "config": {
                     "tables": {
-                        "shiporder": {"fields": {"orderperson": {"transform": False}}}
+                        "shiporder": {"fields": {"orderperson": {"transform": False}}},
+                        "item": None,
                     },
                     "record_hash_column_name": "record_hash",
                     "metadata_columns": [


### PR DESCRIPTION
It can be the case that a table is explicitly configured with a `None` value in the config dict (e.g., from a YAML config file where a key exists but has no value).

This PR considers this possibility by simply checking for `None` values and replacing them with `{}`

One test case was added.

Solves #48