### PR TITLE
Allow xsd:any types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xml2db"
-version = "0.12.5"
+version = "0.12.6"
 authors = [
   { name="Commission de régulation de l'énergie", email="opensource@cre.fr" },
 ]

--- a/src/xml2db/model.py
+++ b/src/xml2db/model.py
@@ -537,6 +537,10 @@ class DataModel:
                             )
                 else:
                     raise ValueError("unknown case; please check")
+            elif type(child) is xmlschema.validators.wildcards.XsdAnyElement:
+                logger.warning(
+                    f"type '{parent_type}' contains a xsd:any child, which is ignored"
+                )
             else:
                 raise ValueError("unknown case; please check (child not an XsdElement)")
 

--- a/src/xml2db/table/column.py
+++ b/src/xml2db/table/column.py
@@ -210,6 +210,8 @@ class DataModelColumn:
                 "dateTime",
                 "NMTOKEN",
                 "time",
+                "base64Binary",  # was added as a fix for accepting more schemas, but not ideal
+                "decimal",  # was added as a fix for accepting more schemas, but not ideal
             ):
                 return True
             raise ValueError(

--- a/tests/sample_models/orders/equivalent_xml/order1a.xml
+++ b/tests/sample_models/orders/equivalent_xml/order1a.xml
@@ -13,6 +13,9 @@
       <companyId>
         <bic>JIDAZIO786DAZH</bic>
       </companyId>
+      <extra>
+        <profileName>profile 1</profileName>
+      </extra>
     </orderperson>
     <item>
       <product>

--- a/tests/sample_models/orders/orders.xsd
+++ b/tests/sample_models/orders/orders.xsd
@@ -19,6 +19,12 @@
         </xs:simpleContent>
     </xs:complexType>
 
+    <xs:complexType name="Extra">
+        <xs:sequence>
+            <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip" />
+        </xs:sequence>
+    </xs:complexType>
+
     <xs:complexType name="contacttype">
         <xs:sequence>
             <xs:element name="name" type="bt:stringtype"/>
@@ -29,6 +35,7 @@
             <xs:element name="phoneNumber" type="bt:stringtype" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="companyId" type="companyIdType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="coordinates" type="bt:CoordinatesListType" minOccurs="0"/>
+            <xs:element name="extra" type="Extra" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>

--- a/tests/sample_models/orders/orders_source_tree_version0.txt
+++ b/tests/sample_models/orders/orders_source_tree_version0.txt
@@ -20,6 +20,7 @@ orders:
                 bic[0, 1]: string
                 lei[0, 1]: string
             coordinates[0, 1]: string
+            extra[0, 1]:
         shipto[0, 1]:
             name_attr[0, 1]: string
             name[1, 1]: string
@@ -36,6 +37,7 @@ orders:
                 bic[0, 1]: string
                 lei[0, 1]: string
             coordinates[0, 1]: string
+            extra[0, 1]:
         item[1, None]:
             product[1, 1]:
                 name[1, 1]: string

--- a/tests/sample_models/orders/orders_source_tree_version1.txt
+++ b/tests/sample_models/orders/orders_source_tree_version1.txt
@@ -20,6 +20,7 @@ orders:
                 bic[0, 1]: string
                 lei[0, 1]: string
             coordinates[0, 1]: string
+            extra[0, 1]:
         shipto[0, 1]:
             name_attr[0, 1]: string
             name[1, 1]: string
@@ -36,6 +37,7 @@ orders:
                 bic[0, 1]: string
                 lei[0, 1]: string
             coordinates[0, 1]: string
+            extra[0, 1]:
         item[1, None]:
             product[1, 1]:
                 name[1, 1]: string

--- a/tests/sample_models/orders/orders_source_tree_version2.txt
+++ b/tests/sample_models/orders/orders_source_tree_version2.txt
@@ -20,6 +20,7 @@ orders:
                 bic[0, 1]: string
                 lei[0, 1]: string
             coordinates[0, 1]: string
+            extra[0, 1]:
         shipto[0, 1]:
             name_attr[0, 1]: string
             name[1, 1]: string
@@ -36,6 +37,7 @@ orders:
                 bic[0, 1]: string
                 lei[0, 1]: string
             coordinates[0, 1]: string
+            extra[0, 1]:
         item[1, None]:
             product[1, 1]:
                 name[1, 1]: string


### PR DESCRIPTION
`xsd:any` types allows arbitrary XML content to be added as a child of another element.

This PR allows XSD schema containing this content, while not saving it to the database as there is no schema information attached to it.