### PR TITLE
Fix KeyError when xs:choice branches share an element with same name and type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xml2db"
-version = "0.13.1"
+version = "0.13.2"
 authors = [
   { name="Commission de régulation de l'énergie", email="opensource@cre.fr" },
 ]

--- a/src/xml2db/table/table.py
+++ b/src/xml2db/table/table.py
@@ -180,6 +180,11 @@ class DataModelTable:
             raise ValueError(
                 "attempting to add a 1-1 relationship with max occurrences different from 1"
             )
+        if (
+            name in self.relations_1
+            and self.relations_1[name].other_table.type_name == other_table.type_name
+        ):
+            return
         rel = DataModelRelation1(
             name,
             [(name, other_table.type_name)],
@@ -206,6 +211,11 @@ class DataModelTable:
             raise ValueError(
                 "attempting to add a 1-n relationship with max occurrences equal to 1"
             )
+        if (
+            name in self.relations_n
+            and self.relations_n[name].other_table.type_name == other_table.type_name
+        ):
+            return
         rel = DataModelRelationN(
             name,
             [(name, other_table.type_name)],

--- a/tests/sample_models/orders/orders.xsd
+++ b/tests/sample_models/orders/orders.xsd
@@ -71,6 +71,18 @@
         </xs:sequence>
     </xs:complexType>
 
+    <!-- deliveryType tests the case where the same element name and complex type appear
+         in two branches of a xs:choice (sequence branch and standalone branch) -->
+    <xs:complexType name="deliveryType">
+        <xs:choice>
+            <xs:sequence>
+                <xs:element name="from" type="contacttype"/>
+                <xs:element name="to" type="contacttype"/>
+            </xs:sequence>
+            <xs:element name="to" type="contacttype"/>
+        </xs:choice>
+    </xs:complexType>
+
     <xs:complexType name="itemtype">
         <xs:sequence>
             <xs:element name="product" type="producttype" minOccurs="1" maxOccurs="1"/>
@@ -78,6 +90,7 @@
             <xs:element name="quantity" type="bt:quantitytype"/>
             <xs:element name="price" type="bt:dectype"/>
             <xs:element name="currency" type="bt:currencytype"/>
+            <xs:element name="delivery" type="deliveryType" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/tests/sample_models/orders/orders_ddl_mssql_version0.sql
+++ b/tests/sample_models/orders/orders_ddl_mssql_version0.sql
@@ -48,9 +48,13 @@ CREATE TABLE item (
 	quantity INTEGER NULL, 
 	price DOUBLE PRECISION NULL, 
 	currency CHAR(3) NULL, 
+	delivery_from_fk_orderperson INTEGER NULL, 
+	delivery_to_fk_orderperson INTEGER NULL, 
 	record_hash BINARY(20) NULL, 
 	CONSTRAINT cx_pk_item PRIMARY KEY CLUSTERED (pk_item), 
-	CONSTRAINT item_xml2db_record_hash UNIQUE (record_hash)
+	CONSTRAINT item_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY(delivery_from_fk_orderperson) REFERENCES orderperson (pk_orderperson), 
+	FOREIGN KEY(delivery_to_fk_orderperson) REFERENCES orderperson (pk_orderperson)
 )
 
 

--- a/tests/sample_models/orders/orders_ddl_mssql_version1.sql
+++ b/tests/sample_models/orders/orders_ddl_mssql_version1.sql
@@ -87,8 +87,12 @@ CREATE TABLE item (
 	quantity INTEGER NULL, 
 	price DOUBLE PRECISION NULL, 
 	currency CHAR(3) NULL, 
+	delivery_from_fk_orderperson INTEGER NULL, 
+	delivery_to_fk_orderperson INTEGER NULL, 
 	CONSTRAINT cx_pk_item PRIMARY KEY CLUSTERED (pk_item), 
-	FOREIGN KEY(fk_parent_shiporder) REFERENCES shiporder (pk_shiporder)
+	FOREIGN KEY(fk_parent_shiporder) REFERENCES shiporder (pk_shiporder), 
+	FOREIGN KEY(delivery_from_fk_orderperson) REFERENCES orderperson (pk_orderperson), 
+	FOREIGN KEY(delivery_to_fk_orderperson) REFERENCES orderperson (pk_orderperson)
 )
 
 

--- a/tests/sample_models/orders/orders_ddl_mssql_version2.sql
+++ b/tests/sample_models/orders/orders_ddl_mssql_version2.sql
@@ -84,10 +84,14 @@ CREATE TABLE item (
 	quantity INTEGER NULL, 
 	price DOUBLE PRECISION NULL, 
 	currency CHAR(3) NULL, 
+	delivery_from_fk_orderperson INTEGER NULL, 
+	delivery_to_fk_orderperson INTEGER NULL, 
 	xml2db_record_hash BINARY(20) NULL, 
 	CONSTRAINT cx_pk_item PRIMARY KEY CLUSTERED (pk_item), 
 	CONSTRAINT item_xml2db_record_hash UNIQUE (xml2db_record_hash), 
-	FOREIGN KEY(fk_product) REFERENCES product (pk_product)
+	FOREIGN KEY(fk_product) REFERENCES product (pk_product), 
+	FOREIGN KEY(delivery_from_fk_orderperson) REFERENCES orderperson (pk_orderperson), 
+	FOREIGN KEY(delivery_to_fk_orderperson) REFERENCES orderperson (pk_orderperson)
 )
 
 

--- a/tests/sample_models/orders/orders_ddl_mysql_version0.sql
+++ b/tests/sample_models/orders/orders_ddl_mysql_version0.sql
@@ -48,9 +48,13 @@ CREATE TABLE item (
 	quantity INTEGER, 
 	price DOUBLE, 
 	currency VARCHAR(3), 
+	delivery_from_fk_orderperson INTEGER, 
+	delivery_to_fk_orderperson INTEGER, 
 	record_hash BINARY(20), 
 	CONSTRAINT cx_pk_item PRIMARY KEY (pk_item), 
-	CONSTRAINT item_xml2db_record_hash UNIQUE (record_hash)
+	CONSTRAINT item_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY(delivery_from_fk_orderperson) REFERENCES orderperson (pk_orderperson), 
+	FOREIGN KEY(delivery_to_fk_orderperson) REFERENCES orderperson (pk_orderperson)
 )
 
 

--- a/tests/sample_models/orders/orders_ddl_mysql_version1.sql
+++ b/tests/sample_models/orders/orders_ddl_mysql_version1.sql
@@ -87,8 +87,12 @@ CREATE TABLE item (
 	quantity INTEGER, 
 	price DOUBLE, 
 	currency VARCHAR(3), 
+	delivery_from_fk_orderperson INTEGER, 
+	delivery_to_fk_orderperson INTEGER, 
 	CONSTRAINT cx_pk_item PRIMARY KEY (pk_item), 
-	FOREIGN KEY(fk_parent_shiporder) REFERENCES shiporder (pk_shiporder)
+	FOREIGN KEY(fk_parent_shiporder) REFERENCES shiporder (pk_shiporder), 
+	FOREIGN KEY(delivery_from_fk_orderperson) REFERENCES orderperson (pk_orderperson), 
+	FOREIGN KEY(delivery_to_fk_orderperson) REFERENCES orderperson (pk_orderperson)
 )
 
 

--- a/tests/sample_models/orders/orders_ddl_mysql_version2.sql
+++ b/tests/sample_models/orders/orders_ddl_mysql_version2.sql
@@ -84,10 +84,14 @@ CREATE TABLE item (
 	quantity INTEGER, 
 	price DOUBLE, 
 	currency VARCHAR(3), 
+	delivery_from_fk_orderperson INTEGER, 
+	delivery_to_fk_orderperson INTEGER, 
 	xml2db_record_hash BINARY(20), 
 	CONSTRAINT cx_pk_item PRIMARY KEY (pk_item), 
 	CONSTRAINT item_xml2db_record_hash UNIQUE (xml2db_record_hash), 
-	FOREIGN KEY(fk_product) REFERENCES product (pk_product)
+	FOREIGN KEY(fk_product) REFERENCES product (pk_product), 
+	FOREIGN KEY(delivery_from_fk_orderperson) REFERENCES orderperson (pk_orderperson), 
+	FOREIGN KEY(delivery_to_fk_orderperson) REFERENCES orderperson (pk_orderperson)
 )
 
 

--- a/tests/sample_models/orders/orders_ddl_postgresql_version0.sql
+++ b/tests/sample_models/orders/orders_ddl_postgresql_version0.sql
@@ -48,9 +48,13 @@ CREATE TABLE item (
 	quantity INTEGER, 
 	price DOUBLE PRECISION, 
 	currency VARCHAR(3), 
+	delivery_from_fk_orderperson INTEGER, 
+	delivery_to_fk_orderperson INTEGER, 
 	record_hash BYTEA, 
 	CONSTRAINT cx_pk_item PRIMARY KEY (pk_item), 
-	CONSTRAINT item_xml2db_record_hash UNIQUE (record_hash)
+	CONSTRAINT item_xml2db_record_hash UNIQUE (record_hash), 
+	FOREIGN KEY(delivery_from_fk_orderperson) REFERENCES orderperson (pk_orderperson), 
+	FOREIGN KEY(delivery_to_fk_orderperson) REFERENCES orderperson (pk_orderperson)
 )
 
 

--- a/tests/sample_models/orders/orders_ddl_postgresql_version1.sql
+++ b/tests/sample_models/orders/orders_ddl_postgresql_version1.sql
@@ -87,8 +87,12 @@ CREATE TABLE item (
 	quantity INTEGER, 
 	price DOUBLE PRECISION, 
 	currency VARCHAR(3), 
+	delivery_from_fk_orderperson INTEGER, 
+	delivery_to_fk_orderperson INTEGER, 
 	CONSTRAINT cx_pk_item PRIMARY KEY (pk_item), 
-	FOREIGN KEY(fk_parent_shiporder) REFERENCES shiporder (pk_shiporder)
+	FOREIGN KEY(fk_parent_shiporder) REFERENCES shiporder (pk_shiporder), 
+	FOREIGN KEY(delivery_from_fk_orderperson) REFERENCES orderperson (pk_orderperson), 
+	FOREIGN KEY(delivery_to_fk_orderperson) REFERENCES orderperson (pk_orderperson)
 )
 
 

--- a/tests/sample_models/orders/orders_ddl_postgresql_version2.sql
+++ b/tests/sample_models/orders/orders_ddl_postgresql_version2.sql
@@ -84,10 +84,14 @@ CREATE TABLE item (
 	quantity INTEGER, 
 	price DOUBLE PRECISION, 
 	currency VARCHAR(3), 
+	delivery_from_fk_orderperson INTEGER, 
+	delivery_to_fk_orderperson INTEGER, 
 	xml2db_record_hash BYTEA, 
 	CONSTRAINT cx_pk_item PRIMARY KEY (pk_item), 
 	CONSTRAINT item_xml2db_record_hash UNIQUE (xml2db_record_hash), 
-	FOREIGN KEY(fk_product) REFERENCES product (pk_product)
+	FOREIGN KEY(fk_product) REFERENCES product (pk_product), 
+	FOREIGN KEY(delivery_from_fk_orderperson) REFERENCES orderperson (pk_orderperson), 
+	FOREIGN KEY(delivery_to_fk_orderperson) REFERENCES orderperson (pk_orderperson)
 )
 
 

--- a/tests/sample_models/orders/orders_erd_version0.md
+++ b/tests/sample_models/orders/orders_erd_version0.md
@@ -12,6 +12,8 @@ erDiagram
         string orderid
         dateTime processed_at
     }
+    item ||--o| orderperson : "delivery_from"
+    item ||--o| orderperson : "delivery_to"
     item ||--o{ intfeature_with_peculiarly_long_suffix_which_overflow_max_length : "product_features_intfeature_with_peculiarly_long_suffix_which_overflow_max_length*"
     item ||--o{ stringfeature : "product_features_stringfeature*"
     item {

--- a/tests/sample_models/orders/orders_erd_version1.md
+++ b/tests/sample_models/orders/orders_erd_version1.md
@@ -1,5 +1,7 @@
 ```mermaid
 erDiagram
+    item ||--o| orderperson : "delivery_from"
+    item ||--o| orderperson : "delivery_to"
     item ||--o{ intfeature_with_peculiarly_long_suffix_which_overflow_max_length : "product_features_intfeature_with_peculiarly_long_suffix_which_overflow_max_length*"
     item ||--o{ stringfeature : "product_features_stringfeature*"
     item {

--- a/tests/sample_models/orders/orders_erd_version2.md
+++ b/tests/sample_models/orders/orders_erd_version2.md
@@ -20,6 +20,8 @@ erDiagram
         string orderperson_a_very_long_field_type_that_makes_col_name_exceeds_max_identifier_length
     }
     item ||--|| product : "product"
+    item ||--o| orderperson : "delivery_from"
+    item ||--o| orderperson : "delivery_to"
     item {
         string note
         integer quantity

--- a/tests/sample_models/orders/orders_source_tree_version0.txt
+++ b/tests/sample_models/orders/orders_source_tree_version0.txt
@@ -55,3 +55,40 @@ orders:
             quantity[1, 1]: integer
             price[1, 1]: decimal
             currency[1, 1]: string
+            delivery[0, 1] (choice):
+                from[0, 1]:
+                    name_attr[0, 1]: string
+                    name[1, 1]: string
+                    address[1, 1]: string
+                    city[1, 1]: string
+                    zip[1, 1]:
+                        codingSystem[0, 1]: string
+                        state[0, 1]: string
+                        value[0, 1]: string
+                    country[1, 1]: string
+                    phoneNumber[0, None]: string
+                    companyId[0, 1] (choice):
+                        ace[0, 1]: string
+                        bic[0, 1]: string
+                        lei[0, 1]: string
+                    coordinates[0, 1]: string
+                    extra[0, 1]:
+                    a_very_long_field_type_that_makes_col_name_exceeds_max_identifier_length[0, 1]: string
+                to[0, 1]:
+                    name_attr[0, 1]: string
+                    name[1, 1]: string
+                    address[1, 1]: string
+                    city[1, 1]: string
+                    zip[1, 1]:
+                        codingSystem[0, 1]: string
+                        state[0, 1]: string
+                        value[0, 1]: string
+                    country[1, 1]: string
+                    phoneNumber[0, None]: string
+                    companyId[0, 1] (choice):
+                        ace[0, 1]: string
+                        bic[0, 1]: string
+                        lei[0, 1]: string
+                    coordinates[0, 1]: string
+                    extra[0, 1]:
+                    a_very_long_field_type_that_makes_col_name_exceeds_max_identifier_length[0, 1]: string

--- a/tests/sample_models/orders/orders_source_tree_version1.txt
+++ b/tests/sample_models/orders/orders_source_tree_version1.txt
@@ -55,3 +55,40 @@ orders:
             quantity[1, 1]: integer
             price[1, 1]: decimal
             currency[1, 1]: string
+            delivery[0, 1] (choice):
+                from[0, 1]:
+                    name_attr[0, 1]: string
+                    name[1, 1]: string
+                    address[1, 1]: string
+                    city[1, 1]: string
+                    zip[1, 1]:
+                        codingSystem[0, 1]: string
+                        state[0, 1]: string
+                        value[0, 1]: string
+                    country[1, 1]: string
+                    phoneNumber[0, None]: string
+                    companyId[0, 1] (choice):
+                        ace[0, 1]: string
+                        bic[0, 1]: string
+                        lei[0, 1]: string
+                    coordinates[0, 1]: string
+                    extra[0, 1]:
+                    a_very_long_field_type_that_makes_col_name_exceeds_max_identifier_length[0, 1]: string
+                to[0, 1]:
+                    name_attr[0, 1]: string
+                    name[1, 1]: string
+                    address[1, 1]: string
+                    city[1, 1]: string
+                    zip[1, 1]:
+                        codingSystem[0, 1]: string
+                        state[0, 1]: string
+                        value[0, 1]: string
+                    country[1, 1]: string
+                    phoneNumber[0, None]: string
+                    companyId[0, 1] (choice):
+                        ace[0, 1]: string
+                        bic[0, 1]: string
+                        lei[0, 1]: string
+                    coordinates[0, 1]: string
+                    extra[0, 1]:
+                    a_very_long_field_type_that_makes_col_name_exceeds_max_identifier_length[0, 1]: string

--- a/tests/sample_models/orders/orders_source_tree_version2.txt
+++ b/tests/sample_models/orders/orders_source_tree_version2.txt
@@ -55,3 +55,40 @@ orders:
             quantity[1, 1]: integer
             price[1, 1]: decimal
             currency[1, 1]: string
+            delivery[0, 1] (choice):
+                from[0, 1]:
+                    name_attr[0, 1]: string
+                    name[1, 1]: string
+                    address[1, 1]: string
+                    city[1, 1]: string
+                    zip[1, 1]:
+                        codingSystem[0, 1]: string
+                        state[0, 1]: string
+                        value[0, 1]: string
+                    country[1, 1]: string
+                    phoneNumber[0, None]: string
+                    companyId[0, 1] (choice):
+                        ace[0, 1]: string
+                        bic[0, 1]: string
+                        lei[0, 1]: string
+                    coordinates[0, 1]: string
+                    extra[0, 1]:
+                    a_very_long_field_type_that_makes_col_name_exceeds_max_identifier_length[0, 1]: string
+                to[0, 1]:
+                    name_attr[0, 1]: string
+                    name[1, 1]: string
+                    address[1, 1]: string
+                    city[1, 1]: string
+                    zip[1, 1]:
+                        codingSystem[0, 1]: string
+                        state[0, 1]: string
+                        value[0, 1]: string
+                    country[1, 1]: string
+                    phoneNumber[0, None]: string
+                    companyId[0, 1] (choice):
+                        ace[0, 1]: string
+                        bic[0, 1]: string
+                        lei[0, 1]: string
+                    coordinates[0, 1]: string
+                    extra[0, 1]:
+                    a_very_long_field_type_that_makes_col_name_exceeds_max_identifier_length[0, 1]: string

--- a/tests/sample_models/orders/orders_target_tree_version0.txt
+++ b/tests/sample_models/orders/orders_target_tree_version0.txt
@@ -45,3 +45,31 @@ orders:
             quantity[1, 1]: integer
             price[1, 1]: decimal
             currency[1, 1]: string
+            delivery_from[0, 1]:
+                name_attr[0, 1]: string
+                name[1, 1]: string
+                address[1, 1]: string
+                city[1, 1]: string
+                zip_codingSystem[0, 1]: string
+                zip_state[0, 1]: string
+                zip_value[0, 1]: string
+                country[1, 1]: string
+                phoneNumber[0, None]: string
+                companyId_type[0, 1]: string
+                companyId_value[0, 1]: string
+                coordinates[0, 1]: string
+                a_very_long_field_type_that_makes_col_name_exceeds_max_identifier_length[0, 1]: string
+            delivery_to[0, 1]:
+                name_attr[0, 1]: string
+                name[1, 1]: string
+                address[1, 1]: string
+                city[1, 1]: string
+                zip_codingSystem[0, 1]: string
+                zip_state[0, 1]: string
+                zip_value[0, 1]: string
+                country[1, 1]: string
+                phoneNumber[0, None]: string
+                companyId_type[0, 1]: string
+                companyId_value[0, 1]: string
+                coordinates[0, 1]: string
+                a_very_long_field_type_that_makes_col_name_exceeds_max_identifier_length[0, 1]: string

--- a/tests/sample_models/orders/orders_target_tree_version1.txt
+++ b/tests/sample_models/orders/orders_target_tree_version1.txt
@@ -47,3 +47,33 @@ orders:
             quantity[1, 1]: integer
             price[1, 1]: decimal
             currency[1, 1]: string
+            delivery_from[0, 1]:
+                name_attr[0, 1]: string
+                name[1, 1]: string
+                address[1, 1]: string
+                city[1, 1]: string
+                zip_codingSystem[0, 1]: string
+                zip_state[0, 1]: string
+                zip_value[0, 1]: string
+                country[1, 1]: string
+                phoneNumber[0, None]: string
+                companyId_ace[0, 1]: string
+                companyId_bic[0, 1]: string
+                companyId_lei[0, 1]: string
+                coordinates[0, 1]: string
+                a_very_long_field_type_that_makes_col_name_exceeds_max_identifier_length[0, 1]: string
+            delivery_to[0, 1]:
+                name_attr[0, 1]: string
+                name[1, 1]: string
+                address[1, 1]: string
+                city[1, 1]: string
+                zip_codingSystem[0, 1]: string
+                zip_state[0, 1]: string
+                zip_value[0, 1]: string
+                country[1, 1]: string
+                phoneNumber[0, None]: string
+                companyId_ace[0, 1]: string
+                companyId_bic[0, 1]: string
+                companyId_lei[0, 1]: string
+                coordinates[0, 1]: string
+                a_very_long_field_type_that_makes_col_name_exceeds_max_identifier_length[0, 1]: string

--- a/tests/sample_models/orders/orders_target_tree_version2.txt
+++ b/tests/sample_models/orders/orders_target_tree_version2.txt
@@ -45,3 +45,31 @@ orders:
             quantity[1, 1]: integer
             price[1, 1]: decimal
             currency[1, 1]: string
+            delivery_from[0, 1]:
+                name_attr[0, 1]: string
+                name[1, 1]: string
+                address[1, 1]: string
+                city[1, 1]: string
+                zip_codingSystem[0, 1]: string
+                zip_state[0, 1]: string
+                zip_value[0, 1]: string
+                country[1, 1]: string
+                phoneNumber[0, None]: string
+                companyId_type[0, 1]: string
+                companyId_value[0, 1]: string
+                coordinates[0, 1]: string
+                a_very_long_field_type_that_makes_col_name_exceeds_max_identifier_length[0, 1]: string
+            delivery_to[0, 1]:
+                name_attr[0, 1]: string
+                name[1, 1]: string
+                address[1, 1]: string
+                city[1, 1]: string
+                zip_codingSystem[0, 1]: string
+                zip_state[0, 1]: string
+                zip_value[0, 1]: string
+                country[1, 1]: string
+                phoneNumber[0, None]: string
+                companyId_type[0, 1]: string
+                companyId_value[0, 1]: string
+                coordinates[0, 1]: string
+                a_very_long_field_type_that_makes_col_name_exceeds_max_identifier_length[0, 1]: string

--- a/tests/sample_models/orders/xml/order3.xml
+++ b/tests/sample_models/orders/xml/order3.xml
@@ -31,6 +31,22 @@
       <quantity>10</quantity>
       <price>12.3</price>
       <currency>EUR</currency>
+      <delivery>
+        <from name="warehouse">
+          <name>Warehouse A</name>
+          <address>1 Depot Road</address>
+          <city>Lyon</city>
+          <zip codingSystem="int">69001</zip>
+          <country>FR</country>
+        </from>
+        <to name="shipping">
+          <name>Bob</name>
+          <address>string</address>
+          <city>string</city>
+          <zip codingSystem="us">102832</zip>
+          <country>FR</country>
+        </to>
+      </delivery>
     </item>
     <item>
       <product>
@@ -41,6 +57,15 @@
       <quantity>21</quantity>
       <price>70.4</price>
       <currency>EUR</currency>
+      <delivery>
+        <to name="shipping">
+          <name>Alice</name>
+          <address>string</address>
+          <city>string</city>
+          <zip codingSystem="int">21093</zip>
+          <country>US</country>
+        </to>
+      </delivery>
     </item>
   </shiporder>
 </orders>


### PR DESCRIPTION
In add_relation_1/add_relation_n, skip duplicate relations where a field with the same name and same XSD type already exists. Previously, self.fields (a list) accumulated both occurrences while self.relations_1/n (dicts) only kept the last, causing a KeyError in simplify_table when the first occurrence was elevated and the second tried to look it up.

Add deliveryType to the orders crash-test schema to cover this case, with order3.xml exercising both the sequence branch (from+to) and standalone branch (to).