### PR TITLE
Fix DuckDB bulk_insert failing when quoted CSV cells fall outside sniffer sample

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xml2db"
-version = "0.13.2"
+version = "0.13.3"
 authors = [
   { name="Commission de régulation de l'énergie", email="opensource@cre.fr" },
 ]

--- a/src/xml2db/dialect/duckdb.py
+++ b/src/xml2db/dialect/duckdb.py
@@ -158,7 +158,7 @@ class DuckDBDialect(DatabaseDialect):
             sql = text(
                 f"INSERT INTO {full_name} ({insert_cols}) "
                 f"SELECT {select_exprs} "
-                f"FROM read_csv('{safe_path}', header=true, nullstr='', all_varchar=true, quote='\"')"
+                f"FROM read_csv('{safe_path}', header=true, nullstr='', all_varchar=true, quote='\"', escape='\"')"
             )
             conn.execute(sql)
         finally:

--- a/src/xml2db/dialect/duckdb.py
+++ b/src/xml2db/dialect/duckdb.py
@@ -158,7 +158,7 @@ class DuckDBDialect(DatabaseDialect):
             sql = text(
                 f"INSERT INTO {full_name} ({insert_cols}) "
                 f"SELECT {select_exprs} "
-                f"FROM read_csv('{safe_path}', header=true, nullstr='', all_varchar=true)"
+                f"FROM read_csv('{safe_path}', header=true, nullstr='', all_varchar=true, quote='\"')"
             )
             conn.execute(sql)
         finally:

--- a/tests/test_bulk_insert.py
+++ b/tests/test_bulk_insert.py
@@ -168,6 +168,27 @@ def test_duckdb_bulk_insert_scalar_column_default(duckdb_engine):
     assert rows[1]["flag"] is False
 
 
+def test_duckdb_bulk_insert_quoted_csv_field_after_large_unquoted_sample(duckdb_engine):
+    """Regression: DuckDB's CSV sniffer uses only the first ~20k rows as a sample.
+
+    If all sampled rows are unquoted, the sniffer sets quote=(empty), causing a
+    column-count error when it later hits a row whose cell value contains a comma
+    (making csv.writer emit a quoted field).  Explicitly passing quote='"' to
+    read_csv bypasses auto-detection and must always be present.
+    """
+    table = _make_table(duckdb_engine, "quoted_field_test")
+    # 'vals' value that contains a comma — document.py's 'join' transform can produce
+    # strings like '"val,ue",other' which csv.writer then wraps in outer quotes,
+    # yielding a quoted CSV cell.
+    problematic_value = '"val,ue",other_value'
+    records = [
+        {"id": i, "label": "simple"} for i in range(25_000)  # exceeds sniffer sample
+    ] + [{"id": 25_000, "label": problematic_value}]
+    rows = _roundtrip(duckdb_engine, table, records)
+    assert len(rows) == 25_001
+    assert rows[-1]["label"] == problematic_value
+
+
 def test_duckdb_bulk_insert_empty(duckdb_engine):
     table = _make_table(duckdb_engine, "empty_test")
     dialect = DuckDBDialect()


### PR DESCRIPTION
## Summary

Fixes #62.

- DuckDB's `read_csv` sniffer examines only the first ~20 480 rows as its sample. If no quoted cells appear in that sample, it sets `quote=(empty)` — meaning it treats `"` as an ordinary character.
- When `join`-transformed columns produce a value containing a comma (e.g. `"val,ue",other`), Python's `csv.writer` wraps the whole cell in outer quotes. Any such cell beyond row ~20 480 would cause a column-count mismatch and an `Invalid Input Error`.
- Fix: pass `quote='"'` explicitly to `read_csv` in `DuckDBDialect.bulk_insert`, bypassing auto-detection entirely.

## Test plan

- [ ] New regression test `test_duckdb_bulk_insert_quoted_csv_field_after_large_unquoted_sample` inserts 25 000 plain rows followed by one row whose `label` contains a comma; verifies all rows are read back correctly.
- [ ] All existing `test_bulk_insert.py` tests still pass.
- [ ] Run full suite: `TZ="Europe/Paris" DB_STRING="duckdb:///:memory:" python -m pytest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)