### PR TITLE
fix: four API-level bug fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xml2db"
-version = "0.13.3"
+version = "0.14.0"
 authors = [
   { name="Commission de régulation de l'énergie", email="opensource@cre.fr" },
 ]

--- a/src/xml2db/dialect/base.py
+++ b/src/xml2db/dialect/base.py
@@ -47,7 +47,7 @@ class DatabaseDialect:
     # Identifier handling
     # ------------------------------------------------------------------
 
-    def db_identifier(self, logical_name: str, temp_prefix: bool = False) -> str:
+    def db_identifier(self, logical_name: str) -> str:
         """Return the physical database identifier for a logical name.
 
         Names longer than :attr:`MAX_IDENTIFIER_LENGTH` are truncated using a
@@ -57,15 +57,12 @@ class DatabaseDialect:
         Args:
             logical_name: The full logical name used inside the Python model
                 (e.g. ``"very_long_table_name_derived_from_xsd"``).
-            temp_prefix: Should we save 14 more characters for the temp prefix?
 
         Returns:
             A string that is safe to use as a database identifier for this
             backend. Guaranteed to be stable across calls with the same input.
         """
         max_len = self.MAX_IDENTIFIER_LENGTH
-        if temp_prefix:
-            max_len += 14
 
         if len(logical_name) <= max_len:
             return logical_name

--- a/src/xml2db/model.py
+++ b/src/xml2db/model.py
@@ -224,7 +224,7 @@ class DataModel:
         # compute a text representation of the original data model and store it
         self.source_tree = str(root_table)
         # check user-provided configuration for tables
-        for tb_config in self.model_config.get("tables", {}):
+        for tb_config in self.tables_config:
             if tb_config not in self.names_types_map:
                 raise DataModelConfigError(
                     f"Table '{tb_config}' provided in config does not exist"

--- a/src/xml2db/table/column.py
+++ b/src/xml2db/table/column.py
@@ -25,7 +25,7 @@ class DataModelColumn:
         is_content: is the column used to store the content value of a mixed complex type?
         allow_empty: is nullable ?
         ngroup: a string key used to handle nested sequences (``str(hash(parent_node))``) or ``None``
-        model_config: the table-level config dict; may contain a ``fields`` entry with a custom column type
+        config: the table-level config dict; may contain a ``fields`` entry with a custom column type
         data_model: the DataModel object it belongs to
 
     Attributes:
@@ -47,7 +47,7 @@ class DataModelColumn:
         is_content: bool,
         allow_empty: bool,
         ngroup: Union[str, None],
-        model_config: dict[str, Any],
+        config: dict[str, Any],
         data_model: "DataModel",
     ):
         """Constructor method"""
@@ -62,7 +62,7 @@ class DataModelColumn:
         self.is_content = is_content
         self.allow_empty = allow_empty
         self.ngroup = ngroup
-        self.model_config = model_config
+        self.config = config
         self.data_model = data_model
         self.other_table = None  # just to avoid a linting warning
 
@@ -101,7 +101,7 @@ class DataModelColumn:
             temp: temp table or target table ?
         """
         # use type specified in config if exists
-        column_type = self.model_config.get("fields", {}).get(self.name, {}).get(
+        column_type = self.config.get("fields", {}).get(self.name, {}).get(
             "type"
         ) or self.data_model.dialect.column_type(self, temp)
         db_col = self.data_model.dialect.db_identifier(self.name)

--- a/src/xml2db/xml_converter.py
+++ b/src/xml2db/xml_converter.py
@@ -46,7 +46,7 @@ class XMLConverter:
         self,
         xml_file: Union[str, BytesIO],
         file_path: str = None,
-        skip_validation: bool = False,
+        skip_validation: bool = True,
         recover: bool = False,
         iterparse: bool = True,
     ) -> tuple:
@@ -57,7 +57,8 @@ class XMLConverter:
         Args:
             xml_file: An XML file path or file content to be converted
             file_path: The file path to be printed in logs
-            skip_validation: Whether we should validate XML against the schema before parsing
+            skip_validation: Whether to skip XML validation against the schema before parsing
+                (default ``True``; set to ``False`` to validate)
             recover: Try to process malformed XML (lxml option)
             iterparse: Parse XML using iterative parsing, which is a bit slower but uses less memory
 


### PR DESCRIPTION
Fixes four bugs identified during a documentation audit.

  - DataModel table-name validation was silently dead. `_build_model iterated` over `self.model_config.get("tables", {})`, but `_validate_config strips` the "tables" key from `self.model_config`, so the loop was always empty.
  Unknown table names passed in model_config were accepted without error. Fixed by iterating over `self.tables_config` instead.
  - `XMLConverter.parse_xml` skip_validation default was inverted. The low-level method defaulted to False (validate), while `Document.parse_xml` and `DataModel.parse_xml` both default to True (skip), matching the documented
  behaviour. Anyone calling `XMLConverter.parse_xml` directly without the keyword argument got silent validation. Aligned to True.
  - `DatabaseDialect.db_identifier` carried a dead `temp_prefix` parameter. It was never passed by any caller anywhere in the codebase. Its implementation (`max_len += 14`) was also the inverse of its stated intent ("save 14
  characters for the prefix"). Removed.
  - `DataModelColumn.model_config` was a misnomer. The attribute stores the table-level config dict (the per-table section of `model_config`), not the top-level model config. Renamed to config to match
  `DataModelTable.config`.